### PR TITLE
Release deployment support

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,0 +1,2 @@
+matches-ignore:
+  - TESTAPP_SECRET

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,17 @@ after_success:
   - TRAVIS_BUILD_DIR=$PWD
   - coverage xml
   - codecov
+#
+# jobs:
+#   include:
+#     - stage: PyPI Release
+#       python: 3.8
+#       before_deploy:
+#         - cd $NAME
+#         - poetry config http-basic.pypi $PYPI_USER $PYPI_PASSWORD
+#         - poetry build
+#       deploy:
+#         provider: script
+#         script: poetry publish
+#         on:
+#           tags: true

--- a/README.md
+++ b/README.md
@@ -2,15 +2,35 @@
 
 This repository is the home of MIT Open Learning's reusable django apps:
 
+| App | Description | Status |
+| --- | --- | --- |
+| [`mitol-django-mail`](mitol-django-mail/) | Mail app and APIs | ![Travis (.com)](https://img.shields.io/travis/com/mitodl/ol-django) ![Codecov](https://img.shields.io/codecov/c/github/mitodl/ol-django?flag=mitol_django_mail) |
 
-- [`mitol-django-mail`](mitol-django-mail/) - Mail app and APIs
+### Releases
 
+Changelogs are maintained according to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Versioning adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Version tags follow `{package-name}/v{major}.{minor}.{patch}`
 
 ### Navigating this repository
 
-Django applications follow the naming convention `mitol-django-{name}`, `pip` installable by the same name. Within the apps, code is implemented under the [implicit namespace](https://www.python.org/dev/peps/pep-0420/) `mitol`, with module paths following the pattern `mitol.{name}`, with the app itself being adding to `INSTALLED_APPS` as `"{name}"`.
+- Django applications follow the naming convention `mitol-django-{name}`, `pip` installable by the same name.
+- Within each app, code is implemented under the [implicit namespace](https://www.python.org/dev/peps/pep-0420/) `mitol`
+  - Module paths follow the pattern `mitol.{name}`
+  - The app itself is installable to `INSTALLED_APPS` as `"{name}"`.
+- Within each app there is also a `testapp` directory that contains a full django app that tests integration of the reusable app. This app also functions as an example of how to use the app.
 
-Within each directory there is also a `testapp` directory that contains a full django app that tests integration of the reusable app. This app also functions as an example of how to use the app.
+### Usage
+
+We use `poetry` and `invoke` to manage apps and releases
+
+- Install [`poetry`](https://python-poetry.org/docs/#installation) (best practice is to not use `pip install`)
+- Install `invoke` and other repo-level deps via `pip install -r requirements.txt`
+
+### Usage
+
+- Install [`poetry`](https://python-poetry.org/docs/#installation) (best practice is to not use `pip install`)
+- Install other deps via `pip install -r requirements.txt`
 
 #### Adding a new app
 

--- a/coverage.yml
+++ b/coverage.yml
@@ -9,11 +9,11 @@ coverage:
     changes:
       default:
         enabled: no
-    mitol-django-mail:
+    mitol_django_mail:
       target: auto
       flags:
-        - mitol-django-mail
+        - mitol_django_mail
 flags:
-  mitol-django-mail:
+  mitol_django_mail:
     paths:
       - mitol-django-mail/

--- a/mitol-django-mail/CHANGELOG.md
+++ b/mitol-django-mail/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Initial port of the `mail` app
+
+[Unreleased]: https://github.com/mitodl/ol-django/compare/v0.1.0...HEAD

--- a/mitol-django-mail/poetry.lock
+++ b/mitol-django-mail/poetry.lock
@@ -533,7 +533,7 @@ description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
 optional = false
 python-versions = ">=3.5"
-version = "2.7.0"
+version = "2.7.1"
 
 [[package]]
 category = "dev"
@@ -1092,8 +1092,8 @@ py = [
     {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
 ]
 pygments = [
-    {file = "Pygments-2.7.0-py3-none-any.whl", hash = "sha256:2df50d16b45b977217e02cba6c8422aaddb859f3d0570a88e09b00eafae89c6e"},
-    {file = "Pygments-2.7.0.tar.gz", hash = "sha256:2594e8fdb06fef91552f86f4fd3a244d148ab24b66042036e64f29a291515048"},
+    {file = "Pygments-2.7.1-py3-none-any.whl", hash = "sha256:307543fe65c0947b126e83dd5a61bd8acbd84abec11f43caebaf5534cbc17998"},
+    {file = "Pygments-2.7.1.tar.gz", hash = "sha256:926c3f319eda178d1bd90851e4317e6d8cdb5e292a3386aac9bd75eca29cf9c7"},
 ]
 pylint = [
     {file = "pylint-2.6.0-py3-none-any.whl", hash = "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"},

--- a/mitol-django-mail/pyproject.toml
+++ b/mitol-django-mail/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mitol-django-mail"
-version = "0.1.0"
+version = "0.0.0"
 description = "MIT Open Learning django app extensions for mail"
 authors = [
   "MIT Office of Open Learning <mitx-devops@mit.edu>"

--- a/mitol-django-mail/testapp/settings/shared.py
+++ b/mitol-django-mail/testapp/settings/shared.py
@@ -22,7 +22,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 # See https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "0541x5@jg^ulh@1gk&9swit)b_@z5by#q*-6ofig@rv!al#1)="
+SECRET_KEY = "TESTAPP_SECRET"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+invoke>=1.4.1
+requests>=2.24.0
+semver>=2.10.2

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,100 @@
+import os
+import sys
+from collections import namedtuple
+from datetime import date
+
+import requests
+
+from invoke import call, task
+import semver
+
+AppName = namedtuple("AppName", ["short", "long"])
+UNRELEASED_HEADER = "## [Unreleased]\n"
+
+
+def _parse_app_name(app_name):
+    """Parse the app name into a short/long version"""
+    return AppName(app_name[len("mitol-django-") :], app_name)
+
+
+@task
+def no_changes(c):
+    """Asserts there's no uncommitted changes"""
+    c.run("git update-index --refresh")
+    if c.run("git diff-index --quiet HEAD --", warn=True).exited != 0:
+        print("Uncommitted changes detected")
+        sys.exit(1)
+
+
+@task(pre=[no_changes])
+def use_branch(c, branch_name):
+    """Switch to a branch"""
+    c.run(f"git checkout {branch_name}")
+    c.run("git pull")
+
+
+@task(
+    # pre=[call(use_branch, "main")],
+    help={
+        "app_name": "the app's name",
+        "version": "the version rule to use, as designated by https://python-poetry.org/docs/cli/#version",
+    },
+)
+def version(c, app_name, version):
+    """Change an app's version and version the changelog"""
+    app_name = _parse_app_name(app_name)
+
+    changelog_path = os.path.join(app_name.long, "CHANGELOG.md")
+    with open(changelog_path, "r") as f:
+        lines = f.readlines()
+
+    if UNRELEASED_HEADER not in lines:
+        print(
+            "Changelog is missing '[Unreleased]' section, please fix before proceeding"
+        )
+        sys.exit(2)
+
+    with c.cd(app_name.long):
+        new_version = c.run(f"poetry version {version}").stdout.split(" ")[-1].strip()
+
+    # initial repo commit if there's no tags for this app
+    initial_ref = c.run(
+        "git rev-list --max-parents=0 HEAD"
+    ).stdout.strip()
+    base_ref = next(
+        iter(sorted(
+            [
+                tag.strip()
+                for tag in c.run("git tag -l").stdout.splitlines()
+                if tag.startswith(f"{app_name.long}-v")
+            ],
+            # sort by semantic versions
+            key=lambda tag: semver.VersionInfo.parse(tag.split("-v")[1])
+        )),
+        initial_ref,
+    )
+    next_ref = f"{app_name.long}-v{new_version}"
+
+    with open(changelog_path, "w") as f:
+        for line in lines:
+            if line == UNRELEASED_HEADER:
+                # prepend the current set of unreleased changes with the current release
+                # effectively moving them down and clearing out unreleased for the next set of changes
+                f.writelines(
+                    [line, "\n", f"## [{new_version}] - {date.today().isoformat()}\n",]
+                )
+            elif line.startswith("[Unreleased]"):
+                # rewrite the unreleased line and add a line for this version
+                f.writelines(
+                    [
+                        f"[Unreleased]: https://github.com/mitodl/ol-django/compare/{new_version}...HEAD",
+                        f"[{new_version}]: https://github.com/mitodl/ol-django/compare/{base_ref}...{new_version}",
+                    ]
+                )
+            else:
+                f.writelines([line])
+
+    c.run("git add .")
+    c.run(f"git commit -m \"Release {next_ref}\"")
+    c.run(f"git tag {next_ref}")
+    # c.run("git push origin main")


### PR DESCRIPTION
- Install the deps in the README
- **Important:** Comment out the line `pre=[call(checkout_branch, "main")],` in `tasks.py`
Test out the versioning command (install deps as instructed in the README):

`invoke version mitol-django-mail minor`

You should see:
- A new commit, which bumps the project version and versions the items in the changelog under "[Unreleased]"
- That commit with a namespaced version tag