### PR TITLE
Updated request structure and added HMAC signature

### DIFF
--- a/mitol-django-digital-credentials/mitol/digitalcredentials/admin.py
+++ b/mitol-django-digital-credentials/mitol/digitalcredentials/admin.py
@@ -1,3 +1,4 @@
+"""Digital credentials admin app"""
 from django.contrib import admin
 
 from mitol.digitalcredentials.models import (

--- a/mitol-django-digital-credentials/mitol/digitalcredentials/factories.py
+++ b/mitol-django-digital-credentials/mitol/digitalcredentials/factories.py
@@ -1,5 +1,4 @@
 """Digital credentials factories"""
-from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from factory import LazyAttribute, SelfAttribute, Sequence, SubFactory
 from factory.django import DjangoModelFactory

--- a/mitol-django-digital-credentials/mitol/digitalcredentials/models.py
+++ b/mitol-django-digital-credentials/mitol/digitalcredentials/models.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
-from mitol.common.models import TimestampedModel, TimestampedModelQuerySet
+from mitol.common.models import TimestampedModel
 
 
 class DigitalCredentialRequest(TimestampedModel):
@@ -45,7 +45,7 @@ class LearnerDID(TimestampedModel):
         """Hashes a DID into sha256"""
         return sha256(did.encode("ascii")).hexdigest()
 
-    def save(self, *args, **kwargs):
+    def save(self, *args, **kwargs):  # pylint: disable=signature-differs
         """Override save() to hash the did"""
         self.did_sha256 = self.sha256_hash_did(self.did)
         return super().save(*args, **kwargs)

--- a/mitol-django-digital-credentials/mitol/digitalcredentials/models_test.py
+++ b/mitol-django-digital-credentials/mitol/digitalcredentials/models_test.py
@@ -6,7 +6,6 @@ from hashlib import sha256
 import pytest
 
 from mitol.digitalcredentials.factories import LearnerDIDFactory
-from mitol.digitalcredentials.models import LearnerDID
 
 
 pytestmark = pytest.mark.django_db

--- a/mitol-django-digital-credentials/mitol/digitalcredentials/requests_utils.py
+++ b/mitol-django-digital-credentials/mitol/digitalcredentials/requests_utils.py
@@ -1,0 +1,67 @@
+"""Digital credentials request utils"""
+import base64
+import hashlib
+import hmac
+from typing import List, NamedTuple
+from urllib.parse import urlparse
+
+from requests.models import PreparedRequest
+
+
+def prepare_request_digest(request: PreparedRequest) -> PreparedRequest:
+    """Prepare the request further by adding a SHA-512 digest header"""
+    if isinstance(request.body, str):
+        body = request.body.encode("utf-8")
+    elif isinstance(request.body, bytes):
+        body = request.body
+    else:
+        raise ValueError(f"Request body cannot be {type(request.body)}")
+    request = request.copy()
+    digest = hashlib.sha512(body).digest()
+    encoded = base64.b64encode(digest).decode("ascii")
+    request.headers["Digest"] = f"SHA512={encoded}"
+    return request
+
+
+class HttpSignatureData(NamedTuple):
+    """HTTP signature and headers"""
+
+    signature: str
+    headers: List[str]
+
+
+def _generate_signature_data(request: PreparedRequest) -> HttpSignatureData:
+    """Generate an http signature"""
+    if not isinstance(request.method, str):
+        raise ValueError("Request.method must be a string")
+    header_names: List[str] = []
+    path = urlparse(request.url).path
+    signing_string_lines = [
+        f"(request-target): {request.method.lower()} {path if isinstance(path, str) else path.decode('utf-8')}"
+    ]
+    for name, value in request.headers.items():
+        name = name.lower()
+        signing_string_lines.append(f"{name}: {value}")
+        header_names.append(name)
+
+    return HttpSignatureData("\n".join(signing_string_lines), header_names)
+
+
+def prepare_request_hmac_signature(
+    request: PreparedRequest, secret: str
+) -> PreparedRequest:
+    """Prepare a request with an HMAC signature header"""
+    request = request.copy()
+
+    signature_data = _generate_signature_data(request)
+    signature_hmac = hmac.new(
+        secret.encode("utf-8"),
+        signature_data.signature.encode("utf-8"),
+        digestmod=hashlib.sha512,
+    )
+    signature = base64.b64encode(signature_hmac.digest()).decode("utf-8")
+    signature_headers = " ".join(signature_data.headers)
+    request.headers[
+        "Signature"
+    ] = f'keyId="abc",algorithm="hmac-sha512",headers="(request-target) {signature_headers}",signature="{signature}"'
+    return request

--- a/mitol-django-digital-credentials/mitol/digitalcredentials/requests_utils_test.py
+++ b/mitol-django-digital-credentials/mitol/digitalcredentials/requests_utils_test.py
@@ -1,0 +1,68 @@
+"""Requests utils tests"""
+import base64
+import hashlib
+
+import pytest
+from requests.models import PreparedRequest
+
+from mitol.digitalcredentials.requests_utils import (
+    prepare_request_digest,
+    prepare_request_hmac_signature,
+)
+
+
+REQUEST_BODY = '{"content": 1}'
+REQUEST_DIGEST = base64.b64encode(
+    hashlib.sha512(REQUEST_BODY.encode("utf-8")).digest()
+).decode("ascii")
+
+
+@pytest.mark.parametrize(
+    "body, expected",
+    [[REQUEST_BODY, REQUEST_DIGEST], [REQUEST_BODY.encode("utf-8"), REQUEST_DIGEST],],
+)
+def test_prepare_request_digest(mocker, body, expected):
+    """Verify prepare_request_digest works as expected"""
+    mock_request = mocker.Mock(spec=PreparedRequest, body=body)
+    mock_request.copy.return_value.headers = {}
+
+    request = prepare_request_digest(mock_request)
+
+    assert request == mock_request.copy.return_value
+    assert request.headers["Digest"] == f"SHA512={expected}"
+
+
+def test_prepare_request_digest_invalid_body(mocker):
+    """Verify prepare_request_digest raises an exception if the body isn't a str oy btes"""
+    mock_request = mocker.Mock(spec=PreparedRequest, body=None)
+
+    with pytest.raises(ValueError):
+        prepare_request_digest(mock_request)
+
+
+def test_prepare_request_hmac_signature(mocker):
+    """Verify prepare_request_hmac_signature works as expected"""
+    mock_request = mocker.Mock(spec=PreparedRequest)
+    copied_request = mock_request.copy.return_value
+    copied_request.method = "POST"
+    copied_request.url = "/my/url"
+    copied_request.headers = {
+        "Digest": "abc",
+        "User-Agent": "digitalcredentials",
+        "Date": "Date: Wed, 21 Oct 2015 07:28:00 GMT",
+    }
+
+    request = prepare_request_hmac_signature(mock_request, "secret")
+    assert request == mock_request.copy.return_value
+    assert request.headers["Signature"] == (
+        'keyId="abc",algorithm="hmac-sha512",headers="(request-target) digest user-agent date",signature="vcHuErUmrcHbaVZ4Ob85XyFNX0fGshZlQh+qorXW497WBuV4inMQLfwWHqAugaXWccL1LvZfZdcH964nuzasmw=="'
+    )
+
+
+def test_prepare_request_hmac_signature_invalid_method(mocker):
+    """Verify prepare_request_hmac_signature raises an error on an invalid method"""
+    mock_request = mocker.Mock(spec=PreparedRequest)
+    copied_request = mock_request.copy.return_value
+    copied_request.method = None
+    with pytest.raises(ValueError):
+        prepare_request_hmac_signature(mock_request, "secret")

--- a/mitol-django-digital-credentials/mitol/digitalcredentials/views.py
+++ b/mitol-django-digital-credentials/mitol/digitalcredentials/views.py
@@ -2,21 +2,10 @@
 import json
 
 from django.db import transaction
-from djangorestframework_camel_case.parser import (
-    CamelCaseFormParser,
-    CamelCaseJSONParser,
-    CamelCaseMultiPartParser,
-)
-from djangorestframework_camel_case.render import (
-    CamelCaseBrowsableAPIRenderer,
-    CamelCaseJSONRenderer,
-)
 from oauth2_provider.contrib.rest_framework import (
     OAuth2Authentication,
     TokenHasReadWriteScope,
-    TokenHasScope,
 )
-from requests import Response as RequestsResponse
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -31,15 +20,6 @@ class DigitalCredentialRequestView(GenericAPIView):
     authentication_classes = [OAuth2Authentication]
     permission_classes = [IsAuthenticated, TokenHasReadWriteScope]
     required_scopes = ["digitalcredentials"]
-    parser_classes = [
-        CamelCaseFormParser,
-        CamelCaseMultiPartParser,
-        CamelCaseJSONParser,
-    ]
-    renderer_classes = [
-        CamelCaseJSONRenderer,
-        CamelCaseBrowsableAPIRenderer,
-    ]
     serializer_class = DigitalCredentialRequestSerializer
     lookup_field = "uuid"
 
@@ -49,7 +29,9 @@ class DigitalCredentialRequestView(GenericAPIView):
 
         return learner.digital_credential_requests.filter(consumed=False)
 
-    def post(self, request: Request, *args, **kwargs):
+    def post(
+        self, request: Request, *args, **kwargs
+    ):  # pylint: disable=unused-argument
         """Consume the credential request for a verified credential"""
         # normally POST is only supported for DRF create operations
         # but we need to map the verb to an update, hence this custom view code

--- a/mitol-django-digital-credentials/mypy.ini
+++ b/mitol-django-digital-credentials/mypy.ini
@@ -7,9 +7,6 @@ plugins =
 [mypy.plugins.django-stubs]
 django_settings_module = "testapp.settings.test"
 
-[mypy-djangorestframework_camel_case.*]
-ignore_missing_imports = True
-
 [mypy-factory.*]
 ignore_missing_imports = True
 

--- a/mitol-django-digital-credentials/poetry.lock
+++ b/mitol-django-digital-credentials/poetry.lock
@@ -189,14 +189,6 @@ version = "3.12.1"
 django = ">=2.2"
 
 [[package]]
-category = "main"
-description = "Camel case JSON support for Django REST framework."
-name = "djangorestframework-camel-case"
-optional = false
-python-versions = ">=3.5"
-version = "1.2.0"
-
-[[package]]
 category = "dev"
 description = "PEP-484 stubs for django-rest-framework"
 name = "djangorestframework-stubs"
@@ -512,7 +504,7 @@ description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
 optional = false
 python-versions = ">=3.5"
-version = "2.7.1"
+version = "2.7.2"
 
 [[package]]
 category = "dev"
@@ -570,7 +562,7 @@ description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
 python-versions = ">=3.5"
-version = "6.1.1"
+version = "6.1.2"
 
 [package.dependencies]
 atomicwrites = ">=1.0"
@@ -659,7 +651,7 @@ description = "Alternative regular expression module, to replace re."
 name = "regex"
 optional = false
 python-versions = "*"
-version = "2020.10.15"
+version = "2020.10.28"
 
 [[package]]
 category = "main"
@@ -795,14 +787,14 @@ marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
 python-versions = ">=3.6"
-version = "3.3.1"
+version = "3.4.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "8b821d2b94b314be98bdaf2b1edec54d51f3efab60fff99b0c6a7e19ea0e2b4f"
+content-hash = "aa411d5d9a394e8b8c7afd9f03b242be0ebbb40cef859c96fafcc42360bd2fb0"
 lock-version = "1.0"
 python-versions = "~3.6 || ~3.7 || ~3.8"
 
@@ -905,9 +897,6 @@ django-stubs = [
 djangorestframework = [
     {file = "djangorestframework-3.12.1-py3-none-any.whl", hash = "sha256:5c5071fcbad6dce16f566d492015c829ddb0df42965d488b878594aabc3aed21"},
     {file = "djangorestframework-3.12.1.tar.gz", hash = "sha256:d54452aedebb4b650254ca092f9f4f5df947cb1de6ab245d817b08b4f4156249"},
-]
-djangorestframework-camel-case = [
-    {file = "djangorestframework-camel-case-1.2.0.tar.gz", hash = "sha256:9714d43fba5bb654057c29501649684d3d9f11a92319ae417fd4d65e80d1159d"},
 ]
 djangorestframework-stubs = [
     {file = "djangorestframework-stubs-1.2.0.tar.gz", hash = "sha256:cd98afa2a7a718689c8aafe162120074976c996f755b0c03d106b6c6c73b95f7"},
@@ -1074,8 +1063,8 @@ py = [
     {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
 ]
 pygments = [
-    {file = "Pygments-2.7.1-py3-none-any.whl", hash = "sha256:307543fe65c0947b126e83dd5a61bd8acbd84abec11f43caebaf5534cbc17998"},
-    {file = "Pygments-2.7.1.tar.gz", hash = "sha256:926c3f319eda178d1bd90851e4317e6d8cdb5e292a3386aac9bd75eca29cf9c7"},
+    {file = "Pygments-2.7.2-py3-none-any.whl", hash = "sha256:88a0bbcd659fcb9573703957c6b9cff9fab7295e6e76db54c9d00ae42df32773"},
+    {file = "Pygments-2.7.2.tar.gz", hash = "sha256:381985fcc551eb9d37c52088a32914e00517e57f4a21609f48141ba08e193fa0"},
 ]
 pylint = [
     {file = "pylint-2.6.0-py3-none-any.whl", hash = "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"},
@@ -1094,8 +1083,8 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-6.1.1-py3-none-any.whl", hash = "sha256:7a8190790c17d79a11f847fba0b004ee9a8122582ebff4729a082c109e81a4c9"},
-    {file = "pytest-6.1.1.tar.gz", hash = "sha256:8f593023c1a0f916110285b6efd7f99db07d59546e3d8c36fc60e2ab05d3be92"},
+    {file = "pytest-6.1.2-py3-none-any.whl", hash = "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe"},
+    {file = "pytest-6.1.2.tar.gz", hash = "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"},
 ]
 pytest-cov = [
     {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
@@ -1118,33 +1107,33 @@ pytz = [
     {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
 ]
 regex = [
-    {file = "regex-2020.10.15-cp27-cp27m-win32.whl", hash = "sha256:e935a166a5f4c02afe3f7e4ce92ce5a786f75c6caa0c4ce09c922541d74b77e8"},
-    {file = "regex-2020.10.15-cp27-cp27m-win_amd64.whl", hash = "sha256:d81be22d5d462b96a2aa5c512f741255ba182995efb0114e5a946fe254148df1"},
-    {file = "regex-2020.10.15-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:6d4cdb6c20e752426b2e569128488c5046fb1b16b1beadaceea9815c36da0847"},
-    {file = "regex-2020.10.15-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:25991861c6fef1e5fd0a01283cf5658c5e7f7aa644128e85243bc75304e91530"},
-    {file = "regex-2020.10.15-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:6e9f72e0ee49f7d7be395bfa29e9533f0507a882e1e6bf302c0a204c65b742bf"},
-    {file = "regex-2020.10.15-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:578ac6379e65eb8e6a85299b306c966c852712c834dc7eef0ba78d07a828f67b"},
-    {file = "regex-2020.10.15-cp36-cp36m-win32.whl", hash = "sha256:65b6b018b07e9b3b6a05c2c3bb7710ed66132b4df41926c243887c4f1ff303d5"},
-    {file = "regex-2020.10.15-cp36-cp36m-win_amd64.whl", hash = "sha256:2f60ba5c33f00ce9be29a140e6f812e39880df8ba9cb92ad333f0016dbc30306"},
-    {file = "regex-2020.10.15-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:5d4a3221f37520bb337b64a0632716e61b26c8ae6aaffceeeb7ad69c009c404b"},
-    {file = "regex-2020.10.15-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:26b85672275d8c7a9d4ff93dbc4954f5146efdb2ecec89ad1de49439984dea14"},
-    {file = "regex-2020.10.15-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:828618f3c3439c5e6ef8621e7c885ca561bbaaba90ddbb6a7dfd9e1ec8341103"},
-    {file = "regex-2020.10.15-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:aef23aed9d4017cc74d37f703d57ce254efb4c8a6a01905f40f539220348abf9"},
-    {file = "regex-2020.10.15-cp37-cp37m-win32.whl", hash = "sha256:6c72adb85adecd4522a488a751e465842cdd2a5606b65464b9168bf029a54272"},
-    {file = "regex-2020.10.15-cp37-cp37m-win_amd64.whl", hash = "sha256:ef3a55b16c6450574734db92e0a3aca283290889934a23f7498eaf417e3af9f0"},
-    {file = "regex-2020.10.15-cp38-cp38-manylinux1_i686.whl", hash = "sha256:8958befc139ac4e3f16d44ec386c490ea2121ed8322f4956f83dd9cad8e9b922"},
-    {file = "regex-2020.10.15-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:3dd952f3f8dc01b72c0cf05b3631e05c50ac65ddd2afdf26551638e97502107b"},
-    {file = "regex-2020.10.15-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:608d6c05452c0e6cc49d4d7407b4767963f19c4d2230fa70b7201732eedc84f2"},
-    {file = "regex-2020.10.15-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:02686a2f0b1a4be0facdd0d3ad4dc6c23acaa0f38fb5470d892ae88584ba705c"},
-    {file = "regex-2020.10.15-cp38-cp38-win32.whl", hash = "sha256:137da580d1e6302484be3ef41d72cf5c3ad22a076070051b7449c0e13ab2c482"},
-    {file = "regex-2020.10.15-cp38-cp38-win_amd64.whl", hash = "sha256:20cdd7e1736f4f61a5161aa30d05ac108ab8efc3133df5eb70fe1e6a23ea1ca6"},
-    {file = "regex-2020.10.15-cp39-cp39-manylinux1_i686.whl", hash = "sha256:85b733a1ef2b2e7001aff0e204a842f50ad699c061856a214e48cfb16ace7d0c"},
-    {file = "regex-2020.10.15-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:af1f5e997dd1ee71fb6eb4a0fb6921bf7a778f4b62f1f7ef0d7445ecce9155d6"},
-    {file = "regex-2020.10.15-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:b5eeaf4b5ef38fab225429478caf71f44d4a0b44d39a1aa4d4422cda23a9821b"},
-    {file = "regex-2020.10.15-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:aeac7c9397480450016bc4a840eefbfa8ca68afc1e90648aa6efbfe699e5d3bb"},
-    {file = "regex-2020.10.15-cp39-cp39-win32.whl", hash = "sha256:698f8a5a2815e1663d9895830a063098ae2f8f2655ae4fdc5dfa2b1f52b90087"},
-    {file = "regex-2020.10.15-cp39-cp39-win_amd64.whl", hash = "sha256:a51e51eecdac39a50ede4aeed86dbef4776e3b73347d31d6ad0bc9648ba36049"},
-    {file = "regex-2020.10.15.tar.gz", hash = "sha256:d25f5cca0f3af6d425c9496953445bf5b288bb5b71afc2b8308ad194b714c159"},
+    {file = "regex-2020.10.28-cp27-cp27m-win32.whl", hash = "sha256:4b5a9bcb56cc146c3932c648603b24514447eafa6ce9295234767bf92f69b504"},
+    {file = "regex-2020.10.28-cp27-cp27m-win_amd64.whl", hash = "sha256:c13d311a4c4a8d671f5860317eb5f09591fbe8259676b86a85769423b544451e"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c8a2b7ccff330ae4c460aff36626f911f918555660cc28163417cb84ffb25789"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4afa350f162551cf402bfa3cd8302165c8e03e689c897d185f16a167328cc6dd"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:b88fa3b8a3469f22b4f13d045d9bd3eda797aa4e406fde0a2644bc92bbdd4bdd"},
+    {file = "regex-2020.10.28-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f43109822df2d3faac7aad79613f5f02e4eab0fc8ad7932d2e70e2a83bd49c26"},
+    {file = "regex-2020.10.28-cp36-cp36m-win32.whl", hash = "sha256:8092a5a06ad9a7a247f2a76ace121183dc4e1a84c259cf9c2ce3bbb69fac3582"},
+    {file = "regex-2020.10.28-cp36-cp36m-win_amd64.whl", hash = "sha256:49461446b783945597c4076aea3f49aee4b4ce922bd241e4fcf62a3e7c61794c"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:8ca9dca965bd86ea3631b975d63b0693566d3cc347e55786d5514988b6f5b84c"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ea37320877d56a7f0a1e6a625d892cf963aa7f570013499f5b8d5ab8402b5625"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:3a5f08039eee9ea195a89e180c5762bfb55258bfb9abb61a20d3abee3b37fd12"},
+    {file = "regex-2020.10.28-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:cb905f3d2e290a8b8f1579d3984f2cfa7c3a29cc7cba608540ceeed18513f520"},
+    {file = "regex-2020.10.28-cp37-cp37m-win32.whl", hash = "sha256:a62162be05edf64f819925ea88d09d18b09bebf20971b363ce0c24e8b4aa14c0"},
+    {file = "regex-2020.10.28-cp37-cp37m-win_amd64.whl", hash = "sha256:03855ee22980c3e4863dc84c42d6d2901133362db5daf4c36b710dd895d78f0a"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux1_i686.whl", hash = "sha256:625116aca6c4b57c56ea3d70369cacc4d62fead4930f8329d242e4fe7a58ce4b"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2dc522e25e57e88b4980d2bdd334825dbf6fa55f28a922fc3bfa60cc09e5ef53"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:119e0355dbdd4cf593b17f2fc5dbd4aec2b8899d0057e4957ba92f941f704bf5"},
+    {file = "regex-2020.10.28-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:cfcf28ed4ce9ced47b9b9670a4f0d3d3c0e4d4779ad4dadb1ad468b097f808aa"},
+    {file = "regex-2020.10.28-cp38-cp38-win32.whl", hash = "sha256:06b52815d4ad38d6524666e0d50fe9173533c9cc145a5779b89733284e6f688f"},
+    {file = "regex-2020.10.28-cp38-cp38-win_amd64.whl", hash = "sha256:c3466a84fce42c2016113101018a9981804097bacbab029c2d5b4fcb224b89de"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c2c6c56ee97485a127555c9595c069201b5161de9d05495fbe2132b5ac104786"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:1ec66700a10e3c75f1f92cbde36cca0d3aaee4c73dfa26699495a3a30b09093c"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:11116d424734fe356d8777f89d625f0df783251ada95d6261b4c36ad27a394bb"},
+    {file = "regex-2020.10.28-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f1fce1e4929157b2afeb4bb7069204d4370bab9f4fc03ca1fbec8bd601f8c87d"},
+    {file = "regex-2020.10.28-cp39-cp39-win32.whl", hash = "sha256:832339223b9ce56b7b15168e691ae654d345ac1635eeb367ade9ecfe0e66bee0"},
+    {file = "regex-2020.10.28-cp39-cp39-win_amd64.whl", hash = "sha256:654c1635f2313d0843028487db2191530bca45af61ca85d0b16555c399625b0e"},
+    {file = "regex-2020.10.28.tar.gz", hash = "sha256:dd3e6547ecf842a29cf25123fbf8d2461c53c8d37aa20d87ecee130c89b7079b"},
 ]
 requests = [
     {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
@@ -1214,6 +1203,6 @@ wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
 ]
 zipp = [
-    {file = "zipp-3.3.1-py3-none-any.whl", hash = "sha256:16522f69653f0d67be90e8baa4a46d66389145b734345d68a257da53df670903"},
-    {file = "zipp-3.3.1.tar.gz", hash = "sha256:c1532a8030c32fd52ff6a288d855fe7adef5823ba1d26a29a68fd6314aa72baa"},
+    {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},
+    {file = "zipp-3.4.0.tar.gz", hash = "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"},
 ]

--- a/mitol-django-digital-credentials/pyproject.toml
+++ b/mitol-django-digital-credentials/pyproject.toml
@@ -25,7 +25,6 @@ python = "~3.6 || ~3.7 || ~3.8"
 Django = "^2.2.12"
 djangorestframework = "^3.10"
 django-oauth-toolkit = "^1.2.0"
-djangorestframework-camel-case = "^1.2.0"
 mitol-django-common = "^0.2.0"
 
 [tool.poetry.dev-dependencies]

--- a/mitol-django-digital-credentials/testapp/integration.py
+++ b/mitol-django-digital-credentials/testapp/integration.py
@@ -10,18 +10,16 @@ def build_credential(courseware_object, learner_did):  # pylint: disable=unused-
                 "https://www.w3.org/2018/credentials/examples/v1",
             ],
             "id": "http://example.gov/credentials/3732",
-            "type": ["VerifiableCredential", "Assertion"],
+            "type": ["VerifiableCredential", "UniversityDegreeCredential"],
             "issuer": "did:web:digitalcredentials.github.io",
             "issuanceDate": "2020-03-10T04:24:12.164Z",
             "credentialSubject": {
                 "type": "Person",
                 "id": learner_did.did,
                 "name": f"{learner_did.learner.first_name} {learner_did.learner.last_name}",
-                "hasAchieved": {
-                    "type": "EducationalOccupationalCredential",
-                    "id": "https://xpro.mit.edu/courses/course-v1:xPRO+AMx/​",
-                    "name": courseware_object.title,
-                    "description": courseware_object.description,
+                "degree": {
+                    "type": "BachelorDegree",
+                    "name": "Bachelor of Science and Arts",
                 },
             },
         },

--- a/mitol-django-digital-credentials/testapp/settings/example.dev.py
+++ b/mitol-django-digital-credentials/testapp/settings/example.dev.py
@@ -10,3 +10,4 @@ from testapp.settings.shared import *
 
 MITOL_DIGITAL_CREDENTIALS_VERIFY_SERVICE_BASE_URL = "http://localhost:5000/"
 MITOL_DIGITAL_CREDENTIALS_BUILD_CREDENTIAL_FUNC = "testapp.integration.build_credential"
+MITOL_DIGITAL_CREDENTIALS_HMAC_SECRET = "abc123"

--- a/mitol-django-digital-credentials/testapp/settings/test.py
+++ b/mitol-django-digital-credentials/testapp/settings/test.py
@@ -4,3 +4,4 @@ from testapp.settings.shared import *
 
 MITOL_DIGITAL_CREDENTIALS_VERIFY_SERVICE_BASE_URL = "http://localhost:5000/"
 MITOL_DIGITAL_CREDENTIALS_BUILD_CREDENTIAL_FUNC = "testapp.integration.build_credential"
+MITOL_DIGITAL_CREDENTIALS_HMAC_SECRET = "abc123"

--- a/mitol-django-digital-credentials/testapp/views_test.py
+++ b/mitol-django-digital-credentials/testapp/views_test.py
@@ -22,6 +22,12 @@ def test_request_credential(learner_and_oauth2):
     response_json = {"result": True}
     responses.add(
         responses.POST,
+        "http://localhost:5000/verify/presentations",
+        json={},
+        status=200,
+    )
+    responses.add(
+        responses.POST,
         "http://localhost:5000/issue/credentials",
         json=response_json,
         status=200,
@@ -31,7 +37,7 @@ def test_request_credential(learner_and_oauth2):
             "digital-credentials:credentials-request",
             kwargs={"uuid": credential_request.uuid},
         ),
-        {"learnerDid": "did:example:abc"},
+        {"id": "did:example:abc"},
         HTTP_AUTHORIZATION=f"Bearer {learner_and_oauth2.access_token.token}",
     )
 
@@ -49,7 +55,7 @@ def test_request_credential_anonymous():
             "digital-credentials:credentials-request",
             kwargs={"uuid": credential_request.uuid},
         ),
-        {"learnerDid": "did:example:abc"},
+        {"id": "did:example:abc"},
     )
     assert response.status_code == HTTPStatus.UNAUTHORIZED
 
@@ -64,7 +70,7 @@ def test_request_credential_wrong_learner(learner_and_oauth2):
             "digital-credentials:credentials-request",
             kwargs={"uuid": credential_request.uuid},
         ),
-        {"learnerDid": "did:example:abc"},
+        {"id": "did:example:abc"},
         HTTP_AUTHORIZATION=f"Bearer {learner_and_oauth2.access_token.token}",
     )
     assert response.status_code == HTTPStatus.NOT_FOUND


### PR DESCRIPTION
Fixes #17
Part of https://github.com/digitalcredentials/sign-and-verify/issues/17

This updates the credential signing API with the following changes:

- Signs request to `sign-and-verify` for credentials with HMAC Signature + Digest headers
- Updates the request body structure to support the new presentation-structured body sent by the wallet app
- Adds a call to perform verification of the learner's presentation 

To test:

- Run [this branch](https://github.com/digitalcredentials/sign-and-verify/pull/18) of the `sign-and-verify` service
- Update `testapp/settings/dev.py`, setting `MITOL_DIGITAL_CREDENTIALS_HMAC_SECRET` to match the shared HMAC secret (any arbitrary string) in the `sign-and-verify` service
- Run the python script + `curl` command it prints in `testapp/README.md`