### PR TITLE
Refactoring and adding more implementations from downstrem

### DIFF
--- a/mitol-django-common/CHANGELOG.md
+++ b/mitol-django-common/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `admin.py` class for `TimestampedModel`
+- Added more utilities from downstream apps, particularly `mitol.common.utils.webpack`
+- Refactored `mitol.common.utils` into a set of smaller subpackages
+- Configured `mitol.common.utils` to re-export utils for backwards compatibility (deprecated for the future though)
+
 ## [0.4.0] - 2021-01-15
 
 ### Added

--- a/mitol-django-common/mitol/common/admin.py
+++ b/mitol-django-common/mitol/common/admin.py
@@ -1,0 +1,47 @@
+"""Django admin functionality that is relevant to the entire app"""
+from django.contrib import admin
+
+
+class TimestampedModelAdmin(admin.ModelAdmin):
+    """
+    A ModelAdmin that includes timestamp fields in the detail view and, optionally, in the list view
+    """
+
+    include_timestamps_in_list = False
+    include_created_on_in_list = False
+
+    @staticmethod
+    def _join_and_dedupe(existing_field_names, field_names_to_add):  # pragma: no cover
+        """
+        Joins two tuples of field names together, and ensures that no duplicate field names are added
+
+        Args:
+            existing_field_names (Tuple[str]): Field names
+            field_names_to_add (Tuple[str]): Field names to add to the existing ones
+
+        Returns:
+            Tuple[str]: The combined field names without any duplicates, unless there were any duplicates in the
+                tuple of existing field names
+        """
+        return existing_field_names + tuple(
+            field for field in field_names_to_add if field not in existing_field_names
+        )
+
+    def get_list_display(self, request):  # pragma: no cover
+        list_display = tuple(super().get_list_display(request) or ())
+        added_fields = ()
+        if self.include_timestamps_in_list:
+            added_fields += ("created_on", "updated_on")
+        elif self.include_created_on_in_list:
+            added_fields += ("created_on",)
+        return self._join_and_dedupe(list_display, added_fields)
+
+    def get_readonly_fields(self, request, obj=None):  # pragma: no cover
+        readonly_fields = tuple(super().get_readonly_fields(request, obj=obj) or ())
+        if obj is None:
+            return readonly_fields
+        return self._join_and_dedupe(readonly_fields, ("created_on", "updated_on"))
+
+    def get_exclude(self, request, obj=None):  # pragma: no cover
+        exclude = tuple(super().get_exclude(request, obj=obj) or ())
+        return self._join_and_dedupe(exclude, ("created_on", "updated_on"))

--- a/mitol-django-common/mitol/common/settings/webpack.py
+++ b/mitol-django-common/mitol/common/settings/webpack.py
@@ -1,0 +1,29 @@
+"""Boilerplate webpack settings parsing"""
+# pragma: no cover
+from mitol.common.envs import get_bool, get_int, get_string
+
+
+WEBPACK_DEV_SERVER_HOST = get_string(
+    name="WEBPACK_DEV_SERVER_HOST",
+    default="",
+    dev_only=True,
+    description="The webpack dev server hostname, development only",
+)
+WEBPACK_DEV_SERVER_PORT = get_int(
+    name="WEBPACK_DEV_SERVER_PORT",
+    default=None,
+    dev_only=True,
+    description="The webpack dev server port, development only",
+)
+WEBPACK_DISABLE_LOADER_STATS = get_bool(
+    name="WEBPACK_DISABLE_LOADER_STATS",
+    default=False,
+    dev_only=True,
+    description="Disables the webpack loader, development environment only.",
+)
+WEBPACK_USE_DEV_SERVER = get_bool(
+    name="WEBPACK_USE_DEV_SERVER",
+    default=False,
+    dev_only=True,
+    description="Enables the webpack devserver, development only",
+)

--- a/mitol-django-common/mitol/common/templatetags/render_bundle.py
+++ b/mitol-django-common/mitol/common/templatetags/render_bundle.py
@@ -1,0 +1,87 @@
+"""Templatetags for rendering webpack bundle script tags"""
+from os import path
+from typing import Any, Dict, Iterator
+
+from django import template
+from django.conf import settings
+from django.http import HttpRequest
+from django.utils.safestring import SafeText, mark_safe
+from webpack_loader.utils import get_loader
+
+from mitol.common.utils.webpack import webpack_public_path
+
+
+register = template.Library()
+
+
+def _get_bundle(request: HttpRequest, bundle_name: str) -> Iterator[dict]:
+    """
+    Update bundle URLs to handle webpack hot reloading correctly if DEBUG=True
+
+    Args:
+        request (django.http.request.HttpRequest): A request
+        bundle_name (str): The name of the webpack bundle
+
+    Returns:
+        iterable of dict:
+            The chunks of the bundle. Usually there's only one but I suppose you could have
+            CSS and JS chunks for one bundle for example
+    """
+    if not settings.WEBPACK_DISABLE_LOADER_STATS:
+        for chunk in get_loader("DEFAULT").get_bundle(bundle_name):
+            chunk_copy = dict(chunk)
+            chunk_copy["url"] = path.join(webpack_public_path(request), chunk["name"])
+            yield chunk_copy
+
+
+@register.simple_tag(takes_context=True)
+def render_bundle(context: Dict[str, Any], bundle_name: str) -> SafeText:
+    """
+    Render the script tags for a Webpack bundle
+
+    We use this instead of webpack_loader.templatetags.webpack_loader.render_bundle because we want to substitute
+    a dynamic URL for webpack dev environments. Maybe in the future we should refactor to use publicPath
+    instead for this.
+
+    Args:
+        context (dict): The context for rendering the template (includes request)
+        bundle_name (str): The name of the bundle to render
+
+    Returns:
+        django.utils.safestring.SafeText:
+    """
+    try:
+        bundle = _get_bundle(context["request"], bundle_name)
+        return _render_tags(bundle)
+    except OSError:
+        # webpack-stats.json doesn't exist
+        return mark_safe("")
+
+
+def _render_tags(bundle: Iterator[dict]) -> SafeText:
+    """
+    Outputs tags for template rendering.
+    Adapted from webpack_loader.utils.get_as_tags and webpack_loader.templatetags.webpack_loader.
+
+    Args:
+        bundle (iterable of dict): The information about a webpack bundle
+
+    Returns:
+        django.utils.safestring.SafeText: HTML for rendering bundles
+    """
+
+    tags = []
+    for chunk in bundle:
+        if chunk["name"].endswith((".js", ".js.gz")):
+            tags.append(
+                ('<script type="text/javascript" src="{}"></script>').format(
+                    chunk["url"]
+                )
+            )
+        elif chunk["name"].endswith((".css", ".css.gz")):
+            tags.append(
+                ('<link type="text/css" href="{}" rel="stylesheet" />').format(
+                    chunk["url"]
+                )
+            )
+    return mark_safe("\n".join(tags))

--- a/mitol-django-common/mitol/common/utils/__init__.py
+++ b/mitol-django-common/mitol/common/utils/__init__.py
@@ -1,0 +1,7 @@
+# Backward compatability
+from mitol.common.utils.collections import *
+from mitol.common.utils.currency import *
+from mitol.common.utils.datetime import *
+from mitol.common.utils.http_requests import *
+from mitol.common.utils.urls import *
+from mitol.common.utils.webpack import *

--- a/mitol-django-common/mitol/common/utils/currency.py
+++ b/mitol-django-common/mitol/common/utils/currency.py
@@ -1,0 +1,15 @@
+"""Currency utilities"""
+from decimal import Decimal
+
+
+def format_price(amount: Decimal) -> str:
+    """
+    Format a price in USD
+
+    Args:
+        amount (decimal.Decimal): A decimal value
+
+    Returns:
+        str: A currency string
+    """
+    return f"${amount:0,.2f}"

--- a/mitol-django-common/mitol/common/utils/datetime.py
+++ b/mitol-django-common/mitol/common/utils/datetime.py
@@ -1,0 +1,29 @@
+"""Datetime utilities"""
+from datetime import datetime, timedelta
+
+import pytz
+
+
+def now_in_utc() -> datetime:
+    """
+    Get the current time in UTC
+    Returns:
+        datetime.datetime: A datetime object for the current time
+    """
+    return datetime.now(tz=pytz.UTC)
+
+
+def is_near_now(time: datetime, epsilon: timedelta = timedelta(seconds=5)) -> bool:
+    """
+    Returns true if time is within five seconds or so of now
+    Args:
+        time (datetime.datetime):
+            The time to test
+        epsilon (datetime.timedelta):
+            The allowed delta in time
+    Returns:
+        bool:
+            True if near now, false otherwise
+    """
+    now = now_in_utc()
+    return now - epsilon < time < now + epsilon

--- a/mitol-django-common/mitol/common/utils/http_requests.py
+++ b/mitol-django-common/mitol/common/utils/http_requests.py
@@ -1,0 +1,68 @@
+"""Requests utilities"""
+import logging
+from http import HTTPStatus
+
+import requests
+from requests import Response
+
+
+log = logging.getLogger(__name__)
+
+
+def get_error_response_summary(response: Response) -> str:
+    """
+    Returns a summary of an error raised from a failed HTTP request using the requests library
+
+    Args:
+        response (requests.Response): The requests library response object
+
+    Returns:
+        str: A summary of the error response
+    """
+    # If the response is an HTML document, include the URL in the summary but not the raw HTML
+    if "text/html" in response.headers.get("Content-Type", ""):
+        summary_dict = {"url": response.url, "content": "(HTML body ignored)"}
+    else:
+        summary_dict = {"content": response.text}
+    summary_dict_str = ", ".join([f"{k}: {v}" for k, v in summary_dict.items()])
+    return f"Response - code: {response.status_code}, {summary_dict_str}"
+
+
+def is_json_response(response: Response) -> bool:
+    """
+    Returns True if the given response object is JSON-parseable
+
+    Args:
+        response (requests.Response): The requests library response object
+
+    Returns:
+        bool: True if this response is JSON-parseable
+    """
+    return response.headers.get("Content-Type") == "application/json"
+
+
+def request_get_with_timeout_retry(url: str, retries: int) -> Response:
+    """
+    Makes a GET request, and retries if the server responds with a 504 (timeout)
+
+    Args:
+        url (str): The URL of the Mailgun API endpoint
+        retries (int): The number of times to retry the request
+
+    Returns:
+        response (requests.models.Response): The requests library response object
+
+    Raises:
+        requests.exceptions.HTTPError: Raised if the response has a status code indicating an error
+    """
+    resp = requests.get(url)
+    # If there was a timeout (504), retry before giving up
+    tries = 1
+    while resp.status_code == HTTPStatus.GATEWAY_TIMEOUT and tries <= retries:
+        tries += 1
+        log.warning(
+            "GET request timed out (%s). Retrying for attempt %d...", url, tries
+        )
+        resp = requests.get(url)
+    resp.raise_for_status()
+    return resp

--- a/mitol-django-common/mitol/common/utils/urls.py
+++ b/mitol-django-common/mitol/common/utils/urls.py
@@ -1,0 +1,38 @@
+"""URL utilities"""
+from urllib.parse import ParseResult, urlparse, urlunparse
+
+
+def ensure_trailing_slash(url: str) -> str:
+    """ensure a url has a trailing slash"""
+    return url if url.endswith("/") else url + "/"
+
+
+def remove_password_from_url(url: str) -> str:
+    """
+    Remove a password from a URL
+
+    Args:
+        url (str): A URL
+
+    Returns:
+        str: A URL without a password
+    """
+    pieces = urlparse(url)
+    netloc = pieces.netloc
+    userinfo, delimiter, hostinfo = netloc.rpartition("@")
+    if delimiter:
+        username, _, _ = userinfo.partition(":")
+        rejoined_netloc = f"{username}{delimiter}{hostinfo}"
+    else:
+        rejoined_netloc = netloc
+
+    return urlunparse(
+        ParseResult(
+            scheme=pieces.scheme,
+            netloc=rejoined_netloc,
+            path=pieces.path,
+            params=pieces.params,
+            query=pieces.query,
+            fragment=pieces.fragment,
+        )
+    )

--- a/mitol-django-common/mitol/common/utils/webpack.py
+++ b/mitol-django-common/mitol/common/utils/webpack.py
@@ -1,0 +1,32 @@
+"""Webpack utilities"""
+from django.conf import settings
+from django.http import HttpRequest
+from django.templatetags.static import static
+
+from mitol.common.utils.urls import ensure_trailing_slash
+
+
+def webpack_public_path(request: HttpRequest) -> str:
+    """
+    Return the correct public_path for Webpack to use
+    """
+    if settings.WEBPACK_USE_DEV_SERVER:
+        return ensure_trailing_slash(webpack_dev_server_url(request))
+    else:
+        return ensure_trailing_slash(static("bundles/"))
+
+
+def webpack_dev_server_host(request: HttpRequest) -> str:
+    """
+    Get the correct webpack dev server host
+    """
+    return settings.WEBPACK_DEV_SERVER_HOST or request.get_host().split(":")[0]
+
+
+def webpack_dev_server_url(request: HttpRequest) -> str:
+    """
+    Get the full URL where the webpack dev server should be running
+    """
+    return "http://{}:{}".format(
+        webpack_dev_server_host(request), settings.WEBPACK_DEV_SERVER_PORT
+    )

--- a/mitol-django-common/poetry.lock
+++ b/mitol-django-common/poetry.lock
@@ -1,86 +1,81 @@
 [[package]]
-category = "main"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 name = "appdirs"
-optional = true
-python-versions = "*"
 version = "1.4.4"
-
-[[package]]
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "main"
-description = "Disable App Nap on macOS >= 10.9"
-marker = "sys_platform == \"darwin\""
-name = "appnope"
 optional = true
 python-versions = "*"
-version = "0.1.2"
 
 [[package]]
+name = "appnope"
+version = "0.1.2"
+description = "Disable App Nap on macOS >= 10.9"
 category = "main"
-description = "ASGI specs, helper code, and adapters"
+optional = true
+python-versions = "*"
+
+[[package]]
 name = "asgiref"
+version = "3.3.1"
+description = "ASGI specs, helper code, and adapters"
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "3.3.1"
 
 [package.extras]
 tests = ["pytest", "pytest-asyncio"]
 
 [[package]]
-category = "main"
-description = "An abstract syntax tree for Python with inference support."
 name = "astroid"
+version = "2.4.2"
+description = "An abstract syntax tree for Python with inference support."
+category = "main"
 optional = true
 python-versions = ">=3.5"
-version = "2.4.2"
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0,<1.5.0"
 six = ">=1.12,<2.0"
+typed-ast = {version = ">=1.4.0,<1.5", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
 wrapt = ">=1.11,<2.0"
 
-[package.dependencies.typed-ast]
-python = "<3.8"
-version = ">=1.4.0,<1.5"
-
 [[package]]
-category = "main"
-description = "Atomic file writes."
-marker = "sys_platform == \"win32\""
 name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.0"
 
 [[package]]
-category = "main"
-description = "Classes Without Boilerplate"
 name = "attrs"
+version = "20.3.0"
+description = "Classes Without Boilerplate"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.3.0"
 
 [package.extras]
-dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
 docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
-category = "main"
-description = "Specifications for callback functions passed in to an API"
 name = "backcall"
+version = "0.2.0"
+description = "Specifications for callback functions passed in to an API"
+category = "main"
 optional = true
 python-versions = "*"
-version = "0.2.0"
 
 [[package]]
-category = "main"
-description = "The uncompromising code formatter."
 name = "black"
+version = "19.10b0"
+description = "The uncompromising code formatter."
+category = "main"
 optional = true
 python-versions = ">=3.6"
-version = "19.10b0"
 
 [package.dependencies]
 appdirs = "*"
@@ -95,64 +90,63 @@ typed-ast = ">=1.4.0"
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
-category = "main"
-description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
+version = "2020.12.5"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
 optional = false
 python-versions = "*"
-version = "2020.12.5"
 
 [[package]]
-category = "main"
-description = "Universal encoding detector for Python 2 and 3"
 name = "chardet"
+version = "4.0.0"
+description = "Universal encoding detector for Python 2 and 3"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "4.0.0"
 
 [[package]]
-category = "main"
-description = "Composable command line interface toolkit"
 name = "click"
-optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "7.1.2"
-
-[[package]]
+description = "Composable command line interface toolkit"
 category = "main"
-description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\""
-name = "colorama"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.4"
 
 [[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
 category = "main"
-description = "Code coverage measurement for Python"
+optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "coverage"
+version = "5.3.1"
+description = "Code coverage measurement for Python"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.3.1"
 
 [package.extras]
 toml = ["toml"]
 
 [[package]]
-category = "main"
-description = "Decorators for Humans"
 name = "decorator"
+version = "4.4.2"
+description = "Decorators for Humans"
+category = "main"
 optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "4.4.2"
 
 [[package]]
-category = "main"
-description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 name = "django"
+version = "3.1.5"
+description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
+category = "main"
 optional = false
 python-versions = ">=3.6"
-version = "3.1.5"
 
 [package.dependencies]
 asgiref = ">=3.2.10,<4"
@@ -164,12 +158,12 @@ argon2 = ["argon2-cffi (>=16.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
-category = "main"
-description = "Mypy stubs for Django"
 name = "django-stubs"
+version = "1.6.0"
+description = "Mypy stubs for Django"
+category = "main"
 optional = true
 python-versions = ">=3.6"
-version = "1.6.0"
 
 [package.dependencies]
 django = "*"
@@ -177,12 +171,20 @@ mypy = ">=0.782,<0.790"
 typing-extensions = "*"
 
 [[package]]
+name = "django-webpack-loader"
+version = "0.7.0"
+description = "Transparently use webpack with django"
 category = "main"
-description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "factory-boy"
+version = "3.2.0"
+description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
+category = "main"
 optional = true
 python-versions = ">=3.6"
-version = "3.2.0"
 
 [package.dependencies]
 Faker = ">=0.7.0"
@@ -192,83 +194,78 @@ dev = ["coverage", "django", "flake8", "isort", "pillow", "sqlalchemy", "mongoen
 doc = ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
-category = "main"
-description = "Faker is a Python package that generates fake data for you."
 name = "faker"
+version = "5.8.0"
+description = "Faker is a Python package that generates fake data for you."
+category = "main"
 optional = true
 python-versions = ">=3.6"
-version = "5.5.1"
 
 [package.dependencies]
 python-dateutil = ">=2.4"
 text-unidecode = "1.3"
 
 [[package]]
-category = "main"
-description = "Let your Python tests travel through time"
 name = "freezegun"
+version = "1.1.0"
+description = "Let your Python tests travel through time"
+category = "main"
 optional = true
 python-versions = ">=3.5"
-version = "1.0.0"
 
 [package.dependencies]
 python-dateutil = ">=2.7"
 
 [[package]]
-category = "main"
-description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
+version = "2.10"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.10"
 
 [[package]]
-category = "main"
-description = "Read metadata from Python packages"
-marker = "python_version < \"3.8\""
 name = "importlib-metadata"
+version = "3.4.0"
+description = "Read metadata from Python packages"
+category = "main"
 optional = true
 python-versions = ">=3.6"
-version = "3.4.0"
 
 [package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
-
-[package.dependencies.typing-extensions]
-python = "<3.8"
-version = ">=3.6.4"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
-category = "main"
-description = "iniconfig: brain-dead simple config-ini parsing"
 name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "main"
 optional = true
 python-versions = "*"
-version = "1.1.1"
 
 [[package]]
-category = "main"
-description = "IPython: Productive Interactive Computing"
 name = "ipython"
+version = "7.16.1"
+description = "IPython: Productive Interactive Computing"
+category = "main"
 optional = true
 python-versions = ">=3.6"
-version = "7.16.1"
 
 [package.dependencies]
-appnope = "*"
+appnope = {version = "*", markers = "sys_platform == \"darwin\""}
 backcall = "*"
-colorama = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
 decorator = "*"
 jedi = ">=0.10"
-pexpect = "*"
+pexpect = {version = "*", markers = "sys_platform != \"win32\""}
 pickleshare = "*"
 prompt-toolkit = ">=2.0.0,<3.0.0 || >3.0.0,<3.0.1 || >3.0.1,<3.1.0"
 pygments = "*"
-setuptools = ">=18.5"
 traitlets = ">=4.2"
 
 [package.extras]
@@ -283,20 +280,20 @@ qtconsole = ["qtconsole"]
 test = ["nose (>=0.10.1)", "requests", "testpath", "pygments", "nbformat", "ipykernel", "numpy (>=1.14)"]
 
 [[package]]
-category = "main"
-description = "Vestigial utilities from IPython"
 name = "ipython-genutils"
+version = "0.2.0"
+description = "Vestigial utilities from IPython"
+category = "main"
 optional = true
 python-versions = "*"
-version = "0.2.0"
 
 [[package]]
-category = "main"
-description = "A Python utility / library to sort Python imports."
 name = "isort"
+version = "4.3.21"
+description = "A Python utility / library to sort Python imports."
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "4.3.21"
 
 [package.extras]
 pipfile = ["pipreqs", "requirementslib"]
@@ -305,43 +302,43 @@ requirements = ["pipreqs", "pip-api"]
 xdg_home = ["appdirs (>=1.4.0)"]
 
 [[package]]
-category = "main"
-description = "An autocompletion tool for Python that can be used for text editors."
 name = "jedi"
+version = "0.18.0"
+description = "An autocompletion tool for Python that can be used for text editors."
+category = "main"
 optional = true
 python-versions = ">=3.6"
-version = "0.18.0"
 
 [package.dependencies]
 parso = ">=0.8.0,<0.9.0"
 
 [package.extras]
-qa = ["flake8 (3.8.3)", "mypy (0.782)"]
+qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
 testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<6.0.0)"]
 
 [[package]]
-category = "main"
-description = "A fast and thorough lazy object proxy."
 name = "lazy-object-proxy"
+version = "1.4.3"
+description = "A fast and thorough lazy object proxy."
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.4.3"
 
 [[package]]
-category = "main"
-description = "McCabe checker, plugin for flake8"
 name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "main"
 optional = true
 python-versions = "*"
-version = "0.6.1"
 
 [[package]]
-category = "main"
-description = "Optional static typing for Python"
 name = "mypy"
+version = "0.782"
+description = "Optional static typing for Python"
+category = "main"
 optional = true
 python-versions = ">=3.5"
-version = "0.782"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
@@ -352,146 +349,142 @@ typing-extensions = ">=3.7.4"
 dmypy = ["psutil (>=4.0)"]
 
 [[package]]
-category = "main"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
 name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "main"
 optional = true
 python-versions = "*"
-version = "0.4.3"
 
 [[package]]
-category = "main"
-description = "Core utilities for Python packages"
 name = "packaging"
+version = "20.8"
+description = "Core utilities for Python packages"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.8"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
 
 [[package]]
-category = "main"
-description = "A Python Parser"
 name = "parso"
+version = "0.8.1"
+description = "A Python Parser"
+category = "main"
 optional = true
 python-versions = ">=3.6"
-version = "0.8.1"
 
 [package.extras]
-qa = ["flake8 (3.8.3)", "mypy (0.782)"]
+qa = ["flake8 (==3.8.3)", "mypy (==0.782)"]
 testing = ["docopt", "pytest (<6.0.0)"]
 
 [[package]]
-category = "main"
-description = "Utility library for gitignore style pattern matching of file paths."
 name = "pathspec"
+version = "0.8.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.8.1"
 
 [[package]]
-category = "main"
-description = "Pexpect allows easy control of interactive console applications."
-marker = "sys_platform != \"win32\""
 name = "pexpect"
+version = "4.8.0"
+description = "Pexpect allows easy control of interactive console applications."
+category = "main"
 optional = true
 python-versions = "*"
-version = "4.8.0"
 
 [package.dependencies]
 ptyprocess = ">=0.5"
 
 [[package]]
-category = "main"
-description = "Tiny 'shelve'-like database with concurrency support"
 name = "pickleshare"
+version = "0.7.5"
+description = "Tiny 'shelve'-like database with concurrency support"
+category = "main"
 optional = true
 python-versions = "*"
-version = "0.7.5"
 
 [[package]]
-category = "main"
-description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.1"
 
 [package.dependencies]
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "main"
-description = "Library for building powerful interactive command lines in Python"
 name = "prompt-toolkit"
+version = "3.0.3"
+description = "Library for building powerful interactive command lines in Python"
+category = "main"
 optional = true
 python-versions = ">=3.6"
-version = "3.0.3"
 
 [package.dependencies]
 wcwidth = "*"
 
 [[package]]
-category = "main"
-description = "psycopg2 - Python-PostgreSQL Database Adapter"
 name = "psycopg2-binary"
+version = "2.8.6"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
-version = "2.8.6"
 
 [[package]]
-category = "main"
-description = "Run a subprocess in a pseudo terminal"
-marker = "sys_platform != \"win32\""
 name = "ptyprocess"
+version = "0.7.0"
+description = "Run a subprocess in a pseudo terminal"
+category = "main"
 optional = true
 python-versions = "*"
-version = "0.7.0"
 
 [[package]]
-category = "main"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
+version = "1.10.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.10.0"
 
 [[package]]
-category = "main"
-description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
+version = "2.7.4"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "main"
 optional = true
 python-versions = ">=3.5"
-version = "2.7.4"
 
 [[package]]
-category = "main"
-description = "python code static checker"
 name = "pylint"
+version = "2.6.0"
+description = "python code static checker"
+category = "main"
 optional = true
 python-versions = ">=3.5.*"
-version = "2.6.0"
 
 [package.dependencies]
 astroid = ">=2.4.0,<=2.5"
-colorama = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
 toml = ">=0.7.1"
 
 [[package]]
-category = "main"
-description = "A Pylint plugin to help Pylint understand the Django web framework"
 name = "pylint-django"
+version = "2.4.2"
+description = "A Pylint plugin to help Pylint understand the Django web framework"
+category = "main"
 optional = true
 python-versions = "*"
-version = "2.4.2"
 
 [package.dependencies]
 pylint = ">=2.0"
@@ -502,71 +495,68 @@ for_tests = ["Faker (<=5.0.1)", "coverage", "django-tables2", "factory-boy", "py
 with_django = ["django"]
 
 [[package]]
-category = "main"
-description = "Utilities and helpers for writing Pylint plugins"
 name = "pylint-plugin-utils"
+version = "0.6"
+description = "Utilities and helpers for writing Pylint plugins"
+category = "main"
 optional = true
 python-versions = "*"
-version = "0.6"
 
 [package.dependencies]
 pylint = ">=1.7"
 
 [[package]]
-category = "main"
-description = "Python parsing module"
 name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "main"
 optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.7"
 
 [[package]]
-category = "main"
-description = "pytest: simple powerful testing with Python"
 name = "pytest"
+version = "6.2.2"
+description = "pytest: simple powerful testing with Python"
+category = "main"
 optional = true
 python-versions = ">=3.6"
-version = "6.2.1"
 
 [package.dependencies]
-atomicwrites = ">=1.0"
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 attrs = ">=19.2.0"
-colorama = "*"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<1.0.0a1"
 py = ">=1.8.2"
 toml = "*"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
-
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-category = "main"
-description = "Pytest plugin for measuring coverage."
 name = "pytest-cov"
+version = "2.11.1"
+description = "Pytest plugin for measuring coverage."
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.10.1"
 
 [package.dependencies]
-coverage = ">=4.4"
+coverage = ">=5.2.1"
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
-category = "main"
-description = "A Django plugin for pytest."
 name = "pytest-django"
+version = "3.10.0"
+description = "A Django plugin for pytest."
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.10.0"
 
 [package.dependencies]
 pytest = ">=3.6"
@@ -576,12 +566,12 @@ docs = ["sphinx", "sphinx-rtd-theme"]
 testing = ["django", "django-configurations (>=2.0)", "six"]
 
 [[package]]
-category = "main"
-description = "Thin-wrapper around the mock package for easier use with py.test"
 name = "pytest-mock"
+version = "1.10.1"
+description = "Thin-wrapper around the mock package for easier use with py.test"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.10.1"
 
 [package.dependencies]
 pytest = ">=2.7"
@@ -590,39 +580,39 @@ pytest = ">=2.7"
 dev = ["pre-commit", "tox"]
 
 [[package]]
-category = "main"
-description = "Extensions to the standard Python datetime module"
 name = "python-dateutil"
+version = "2.8.1"
+description = "Extensions to the standard Python datetime module"
+category = "main"
 optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-version = "2.8.1"
 
 [package.dependencies]
 six = ">=1.5"
 
 [[package]]
-category = "main"
-description = "World timezone definitions, modern and historical"
 name = "pytz"
+version = "2020.5"
+description = "World timezone definitions, modern and historical"
+category = "main"
 optional = false
 python-versions = "*"
-version = "2020.5"
 
 [[package]]
-category = "main"
-description = "Alternative regular expression module, to replace re."
 name = "regex"
+version = "2020.11.13"
+description = "Alternative regular expression module, to replace re."
+category = "main"
 optional = true
 python-versions = "*"
-version = "2020.11.13"
 
 [[package]]
-category = "main"
-description = "Python HTTP for Humans."
 name = "requests"
+version = "2.25.1"
+description = "Python HTTP for Humans."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.25.1"
 
 [package.dependencies]
 certifi = ">=2017.4.17"
@@ -632,47 +622,63 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 
 [[package]]
+name = "responses"
+version = "0.12.1"
+description = "A utility library for mocking out the `requests` Python library."
 category = "main"
-description = "Python 2 and 3 compatibility utilities"
+optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+requests = ">=2.0"
+six = "*"
+urllib3 = ">=1.25.10"
+
+[package.extras]
+tests = ["coverage (>=3.7.1,<6.0.0)", "pytest-cov", "pytest-localserver", "flake8", "pytest (>=4.6,<5.0)", "pytest (>=4.6)"]
+
+[[package]]
 name = "six"
+version = "1.15.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
 optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.15.0"
 
 [[package]]
-category = "main"
-description = "A non-validating SQL parser."
 name = "sqlparse"
+version = "0.4.1"
+description = "A non-validating SQL parser."
+category = "main"
 optional = false
 python-versions = ">=3.5"
-version = "0.4.1"
 
 [[package]]
-category = "main"
-description = "The most basic Text::Unidecode port"
 name = "text-unidecode"
+version = "1.3"
+description = "The most basic Text::Unidecode port"
+category = "main"
 optional = true
 python-versions = "*"
-version = "1.3"
 
 [[package]]
-category = "main"
-description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "main"
 optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "0.10.2"
 
 [[package]]
-category = "main"
-description = "Traitlets Python config system"
 name = "traitlets"
+version = "4.3.3"
+description = "Traitlets Python config system"
+category = "main"
 optional = true
 python-versions = "*"
-version = "4.3.3"
 
 [package.dependencies]
 decorator = "*"
@@ -683,72 +689,71 @@ six = "*"
 test = ["pytest", "mock"]
 
 [[package]]
-category = "main"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
 name = "typed-ast"
-optional = true
-python-versions = "*"
 version = "1.4.2"
-
-[[package]]
+description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "main"
-description = "Backported and Experimental Type Hints for Python 3.5+"
-name = "typing-extensions"
 optional = true
 python-versions = "*"
-version = "3.7.4.3"
 
 [[package]]
+name = "typing-extensions"
+version = "3.7.4.3"
+description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
-description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = true
+python-versions = "*"
+
+[[package]]
 name = "urllib3"
+version = "1.26.3"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.26.2"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-category = "main"
-description = "Measures the displayed width of unicode strings in a terminal"
 name = "wcwidth"
-optional = true
-python-versions = "*"
 version = "0.2.5"
-
-[[package]]
+description = "Measures the displayed width of unicode strings in a terminal"
 category = "main"
-description = "Module for decorators, wrappers and monkey patching."
-name = "wrapt"
 optional = true
 python-versions = "*"
-version = "1.12.1"
 
 [[package]]
+name = "wrapt"
+version = "1.12.1"
+description = "Module for decorators, wrappers and monkey patching."
 category = "main"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\""
+optional = true
+python-versions = "*"
+
+[[package]]
 name = "zipp"
+version = "3.4.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "main"
 optional = true
 python-versions = ">=3.6"
-version = "3.4.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
 celery = []
 dev = ["ipython"]
-test = ["pytest", "pytest-cov", "pytest-mock", "pytest-django", "freezegun", "factory_boy", "isort", "black", "pylint", "pylint-django", "mypy", "django-stubs"]
+test = ["pytest", "pytest-cov", "pytest-mock", "pytest-django", "freezegun", "factory_boy", "responses", "coverage", "isort", "black", "pylint", "pylint-django", "mypy", "django-stubs"]
 
 [metadata]
-content-hash = "1489817221003909086dc3747738894ab8edc9fb40a5874eb9f9e9e8db70ac08"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "~3.6 || ~3.7 || ~3.8"
+content-hash = "6edb1d0af1573d4fdebbe6a277c58aaf7ff7c5dcf229c8c198c87604720f0fb6"
 
 [metadata.files]
 appdirs = [
@@ -861,17 +866,21 @@ django-stubs = [
     {file = "django-stubs-1.6.0.tar.gz", hash = "sha256:5257eaedf50e9a294d45618a878baaa1fc6f21b72ebb927c2a87d37a55ca6c50"},
     {file = "django_stubs-1.6.0-py3-none-any.whl", hash = "sha256:20759904040bd29783a5ff879b48ad965964b8a9ea9e405cc49a435423d0d5ba"},
 ]
+django-webpack-loader = [
+    {file = "django-webpack-loader-0.7.0.tar.gz", hash = "sha256:7a3c88201aa54481f9399465615cbe7b9aece8081496a6d0287b7cb8e232f447"},
+    {file = "django_webpack_loader-0.7.0-py2.py3-none-any.whl", hash = "sha256:d28a276ed3d89e97a313b74967e373693f8b86afe629f4c91eea91c5b4f2ec20"},
+]
 factory-boy = [
     {file = "factory_boy-3.2.0-py2.py3-none-any.whl", hash = "sha256:1d3db4b44b8c8c54cdd8b83ae4bdb9aeb121e464400035f1f03ae0e1eade56a4"},
     {file = "factory_boy-3.2.0.tar.gz", hash = "sha256:401cc00ff339a022f84d64a4339503d1689e8263a4478d876e58a3295b155c5b"},
 ]
 faker = [
-    {file = "Faker-5.5.1-py3-none-any.whl", hash = "sha256:ec1f502d85e6ca6b47d651ccd797c18a67c8a184cbbea5de37a253ced360258d"},
-    {file = "Faker-5.5.1.tar.gz", hash = "sha256:29b0f01e5c3f499f15798aeed5ebd0e6dad7ab90651479e48d52851c638553af"},
+    {file = "Faker-5.8.0-py3-none-any.whl", hash = "sha256:0783729c61501d52efea2967aff6e6fcb8370f0f6b5a558f2a81233642ae529a"},
+    {file = "Faker-5.8.0.tar.gz", hash = "sha256:6b2995ffff6c2b02bc5daad96f8c24c021e5bd491d9d53d31bcbd66f348181d4"},
 ]
 freezegun = [
-    {file = "freezegun-1.0.0-py2.py3-none-any.whl", hash = "sha256:02b35de52f4699a78f6ac4518e4cd3390dddc43b0aeb978335a8f270a2d9668b"},
-    {file = "freezegun-1.0.0.tar.gz", hash = "sha256:1cf08e441f913ff5e59b19cc065a8faa9dd1ddc442eaf0375294f344581a0643"},
+    {file = "freezegun-1.1.0-py2.py3-none-any.whl", hash = "sha256:2ae695f7eb96c62529f03a038461afe3c692db3465e215355e1bb4b0ab408712"},
+    {file = "freezegun-1.1.0.tar.gz", hash = "sha256:177f9dd59861d871e27a484c3332f35a6e3f5d14626f2bf91be37891f18927f3"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -1038,12 +1047,12 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-6.2.1-py3-none-any.whl", hash = "sha256:1969f797a1a0dbd8ccf0fecc80262312729afea9c17f1d70ebf85c5e76c6f7c8"},
-    {file = "pytest-6.2.1.tar.gz", hash = "sha256:66e419b1899bc27346cb2c993e12c5e5e8daba9073c1fbce33b9807abc95c306"},
+    {file = "pytest-6.2.2-py3-none-any.whl", hash = "sha256:b574b57423e818210672e07ca1fa90aaf194a4f63f3ab909a2c67ebb22913839"},
+    {file = "pytest-6.2.2.tar.gz", hash = "sha256:9d1edf9e7d0b84d72ea3dbcdfd22b35fb543a5e8f2a60092dd578936bf63d7f9"},
 ]
 pytest-cov = [
-    {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
-    {file = "pytest_cov-2.10.1-py2.py3-none-any.whl", hash = "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191"},
+    {file = "pytest-cov-2.11.1.tar.gz", hash = "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7"},
+    {file = "pytest_cov-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"},
 ]
 pytest-django = [
     {file = "pytest-django-3.10.0.tar.gz", hash = "sha256:4de6dbd077ed8606616958f77655fed0d5e3ee45159475671c7fa67596c6dba6"},
@@ -1108,6 +1117,10 @@ requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
     {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
 ]
+responses = [
+    {file = "responses-0.12.1-py2.py3-none-any.whl", hash = "sha256:ef265bd3200bdef5ec17912fc64a23570ba23597fd54ca75c18650fa1699213d"},
+    {file = "responses-0.12.1.tar.gz", hash = "sha256:2e5764325c6b624e42b428688f2111fea166af46623cb0127c05f6afb14d3457"},
+]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
@@ -1166,8 +1179,8 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.2-py2.py3-none-any.whl", hash = "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"},
-    {file = "urllib3-1.26.2.tar.gz", hash = "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08"},
+    {file = "urllib3-1.26.3-py2.py3-none-any.whl", hash = "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80"},
+    {file = "urllib3-1.26.3.tar.gz", hash = "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/mitol-django-common/pyproject.toml
+++ b/mitol-django-common/pyproject.toml
@@ -27,6 +27,7 @@ python = "~3.6 || ~3.7 || ~3.8"
 Django = "^2.2.12 || ~3.0 || ~3.1"
 psycopg2-binary = "^2.8.3"
 requests = "^2.20.0"
+django-webpack-loader = "^0.7.0"
 
 # Testers
 pytest = {version = "^6.0.2", optional = true}
@@ -35,6 +36,8 @@ pytest-mock = {version = "1.10.1", optional = true}
 pytest-django = {version = "3.10.0", optional = true}
 freezegun = {version = "^1.0.0", optional = true}
 factory_boy = {version = "^3.0.0", optional = true}
+responses = {version = "^0.12.0", optional = true}
+coverage = {version= "5.3.1", optional = true}
 
 # Formatters
 isort = {version = "^4.3.21", optional = true}
@@ -52,7 +55,7 @@ ipython = {version = "^7.13.0", optional = true}
 [tool.poetry.extras]
 celery = ["celery"]
 test = [
-  "pytest", "pytest-cov", "pytest-mock", "pytest-django", "freezegun", "factory_boy",
+  "pytest", "pytest-cov", "pytest-mock", "pytest-django", "freezegun", "factory_boy", "responses", "coverage",
   "isort", "black",
   "pylint", "pylint-django", "mypy", "django-stubs",
 ]

--- a/mitol-django-common/testapp/settings/shared.py
+++ b/mitol-django-common/testapp/settings/shared.py
@@ -12,6 +12,8 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import os
 
+from mitol.common.settings.webpack import *
+
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 # multiple dinames to get up to mitol-django-mail/

--- a/mitol-django-common/tests/templates/test_render_bundle.py
+++ b/mitol-django-common/tests/templates/test_render_bundle.py
@@ -1,0 +1,106 @@
+"""
+Tests for mitol.common.templatetags.render_bundle
+"""
+from os import path
+
+import pytest
+from django.template import Context, Template
+
+
+FAKE_COMMON_BUNDLE = [
+    {
+        "name": "common-1f11431a92820b453513.js",
+        "path": "/project/static/bundles/common-1f11431a92820b453513.js",
+    },
+    {
+        "name": "styles-1f123456670b45387513.css",
+        "path": "/project/static/bundles/styles-1f123456670b45387513.css",
+    },
+    {
+        "name": "misc-84685678567856785688.txt",
+        "path": "/project/static/bundles/misc-84685678567856785688.txt",
+    },
+]
+
+
+@pytest.fixture(autouse=True)
+def dont_disable_webpack(settings):
+    """Re-enable webpack loader stats for these tests."""
+    settings.WEBPACK_DISABLE_LOADER_STATS = False
+
+
+def test_render_bundle_disable_loader_stats(settings, mocker, rf):
+    """Verify it renders nothing if WEBPACK_DISABLE_LOADER_STATS = True"""
+    settings.WEBPACK_DISABLE_LOADER_STATS = True
+    request = rf.get("/")
+    get_loader = mocker.patch("mitol.common.templatetags.render_bundle.get_loader")
+
+    context = Context({"request": request})
+    template = Template("{% load render_bundle %}{% render_bundle 'bundle_name' %}")
+    assert template.render(context) == ""
+
+    get_loader.assert_not_called()
+
+
+def test_render_bundle(mocker, rf):
+    """Verify render_bundle returns the path to the bundle with the correct base url"""
+    request = rf.get("/")
+    context = {"request": request}
+
+    # convert to generator
+    common_bundle = (chunk for chunk in FAKE_COMMON_BUNDLE)
+    get_bundle = mocker.Mock(return_value=common_bundle)
+    loader = mocker.Mock(get_bundle=get_bundle)
+    bundle_name = "bundle_name"
+
+    get_loader = mocker.patch(
+        "mitol.common.templatetags.render_bundle.get_loader", return_value=loader
+    )
+    mock_webpack_public_path = mocker.patch(
+        "mitol.common.templatetags.render_bundle.webpack_public_path", return_value="/"
+    )
+
+    context = Context({"request": request})
+    template = Template(
+        "{{% load render_bundle %}}{{% render_bundle '{bundle_name}' %}}".format(
+            bundle_name=bundle_name
+        )
+    )
+
+    script_url = path.join("/", FAKE_COMMON_BUNDLE[0]["name"])
+    style_url = path.join("/", FAKE_COMMON_BUNDLE[1]["name"])
+    assert template.render(context) == "\n".join(
+        [
+            '<script type="text/javascript" src="{}"></script>'.format(script_url),
+            '<link type="text/css" href="{}" rel="stylesheet" />'.format(style_url),
+        ]
+    )
+
+    get_bundle.assert_called_with(bundle_name)
+    get_loader.assert_called_with("DEFAULT")
+
+
+def test_render_bundle_missing_file(mocker, rf):
+    """
+    If webpack-stats.json is missing, return an empty string
+    """
+    request = rf.get("/")
+    context = {"request": request}
+
+    get_bundle = mocker.Mock(side_effect=OSError)
+    loader = mocker.Mock(get_bundle=get_bundle)
+    bundle_name = "bundle_name"
+    get_loader = mocker.patch(
+        "mitol.common.templatetags.render_bundle.get_loader", return_value=loader
+    )
+
+    context = Context({"request": request})
+    template = Template(
+        "{{% load render_bundle %}}{{% render_bundle '{bundle_name}' %}}".format(
+            bundle_name=bundle_name
+        )
+    )
+    assert template.render(context) == ""
+
+    get_bundle.assert_called_with(bundle_name)
+    get_loader.assert_called_with("DEFAULT")

--- a/mitol-django-common/tests/utils/test_currency.py
+++ b/mitol-django-common/tests/utils/test_currency.py
@@ -1,0 +1,15 @@
+"""Utils tests"""
+from decimal import Decimal
+
+import pytest
+
+from mitol.common.utils.currency import format_price
+
+
+@pytest.mark.parametrize(
+    "price,expected",
+    [[Decimal("0"), "$0.00"], [Decimal("1234567.89"), "$1,234,567.89"]],
+)
+def test_format_price(price, expected):
+    """Format a decimal value into a price"""
+    assert format_price(price) == expected

--- a/mitol-django-common/tests/utils/test_datetime.py
+++ b/mitol-django-common/tests/utils/test_datetime.py
@@ -1,0 +1,30 @@
+"""Utils tests"""
+from datetime import datetime, timedelta
+
+import pytest
+import pytz
+
+from mitol.common.utils.datetime import is_near_now, now_in_utc
+
+
+def test_now_in_utc():
+    """now_in_utc() should return the current time set to the UTC time zone"""
+    now = now_in_utc()
+    assert is_near_now(now)
+    assert now.tzinfo == pytz.UTC
+
+
+def test_is_near_now():
+    """Test is_near_now for now"""
+    now = datetime.now(tz=pytz.UTC)
+    assert is_near_now(now) is True
+    later = now + timedelta(seconds=6)
+    assert is_near_now(later) is False
+    earlier = now - timedelta(seconds=6)
+    assert is_near_now(earlier) is False
+    # with an epsilon specified
+    assert is_near_now(now, timedelta(seconds=30)) is True
+    later = now + timedelta(seconds=35)
+    assert is_near_now(later, timedelta(seconds=30)) is False
+    earlier = now - timedelta(seconds=35)
+    assert is_near_now(earlier, timedelta(seconds=30)) is False

--- a/mitol-django-common/tests/utils/test_http_requests.py
+++ b/mitol-django-common/tests/utils/test_http_requests.py
@@ -1,0 +1,89 @@
+"""Utils tests"""
+from http import HTTPStatus
+
+import pytest
+import responses
+from requests.exceptions import HTTPError
+
+from mitol.common.pytest_utils import MockResponse
+from mitol.common.utils.http_requests import (
+    get_error_response_summary,
+    is_json_response,
+    request_get_with_timeout_retry,
+)
+
+
+@pytest.mark.parametrize(
+    "content,content_type,exp_summary_content,exp_url_in_summary",
+    [
+        ['{"bad": "response"}', "application/json", '{"bad": "response"}', False],
+        ["plain text", "text/plain", "plain text", False],
+        [
+            "<div>HTML content</div>",
+            "text/html; charset=utf-8",
+            "(HTML body ignored)",
+            True,
+        ],
+    ],
+)
+def test_get_error_response_summary(
+    content, content_type, exp_summary_content, exp_url_in_summary
+):
+    """
+    get_error_response_summary should provide a summary of an error HTTP response object with the correct bits of
+    information depending on the type of content.
+    """
+    status_code = 400
+    url = "http://example.com"
+    mock_response = MockResponse(
+        status_code=status_code, content=content, content_type=content_type, url=url
+    )
+    summary = get_error_response_summary(mock_response)
+    assert f"Response - code: {status_code}" in summary
+    assert f"content: {exp_summary_content}" in summary
+    assert (f"url: {url}" in summary) is exp_url_in_summary
+
+
+@pytest.mark.parametrize(
+    "content,content_type,expected",
+    [
+        ['{"bad": "response"}', "application/json", True],
+        ["plain text", "text/plain", False],
+        ["<div>HTML content</div>", "text/html; charset=utf-8", False],
+    ],
+)
+def test_is_json_response(content, content_type, expected):
+    """
+    is_json_response should return True if the given response's content type indicates JSON content
+    """
+    mock_response = MockResponse(
+        status_code=400, content=content, content_type=content_type
+    )
+    assert is_json_response(mock_response) is expected
+
+
+@responses.activate
+@pytest.mark.parametrize("num_failures", range(4))
+def test_request_get_with_timeout_retry(mocker, num_failures):
+    """request_get_with_timeout_retry should make a GET request and retry if the response status is 504 (timeout)"""
+    patched_log = mocker.patch("mitol.common.utils.http_requests.log")
+    url = "http://example.com/retry"
+    retries = 3
+    data = {"data": 1}
+    for num_retry in range(retries):
+        if num_retry < num_failures:
+            responses.add(responses.GET, url, status=HTTPStatus.GATEWAY_TIMEOUT)
+        else:
+            responses.add(responses.GET, url, json=data)
+
+    if num_failures < retries:
+        result = request_get_with_timeout_retry(url, retries=retries)
+        assert len(responses.calls) == num_failures + 1
+
+        assert result.status_code == HTTPStatus.OK
+        assert result.json() == data
+    else:
+        with pytest.raises(HTTPError):
+            request_get_with_timeout_retry(url, retries=retries)
+
+    assert patched_log.warning.call_count == num_failures

--- a/mitol-django-common/tests/utils/test_urls.py
+++ b/mitol-django-common/tests/utils/test_urls.py
@@ -1,0 +1,23 @@
+"""URLs utils tests"""
+import pytest
+
+from mitol.common.utils.urls import ensure_trailing_slash, remove_password_from_url
+
+
+def test_ensure_trailing_slash():
+    """Verify ensure_trailing_slash() enforces a single slash on the end"""
+    assert ensure_trailing_slash("http://example.com") == "http://example.com/"
+    assert ensure_trailing_slash("http://example.com/") == "http://example.com/"
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ["", ""],
+        ["http://url.com/url/here#other", "http://url.com/url/here#other"],
+        ["https://user:pass@sentry.io/12345", "https://user@sentry.io/12345"],
+    ],
+)
+def test_remove_password_from_url(url, expected):
+    """Assert that the url is parsed and the password is not present in the returned value, if provided"""
+    assert remove_password_from_url(url) == expected

--- a/mitol-django-common/tests/utils/test_webpack.py
+++ b/mitol-django-common/tests/utils/test_webpack.py
@@ -1,0 +1,38 @@
+"""Webpack utils tests"""
+from mitol.common.utils.webpack import (
+    webpack_dev_server_host,
+    webpack_dev_server_url,
+    webpack_public_path,
+)
+
+
+def test_webpack_public_path(rf, settings, mocker):
+    """Test public_path() behaviors"""
+    request = rf.get("/")
+
+    mock_webpack_dev_server_url = mocker.patch(
+        "mitol.common.utils.webpack.webpack_dev_server_url", return_value="/dev/server"
+    )
+
+    settings.WEBPACK_USE_DEV_SERVER = True
+    assert webpack_public_path(request) == "/dev/server/"
+
+    settings.WEBPACK_USE_DEV_SERVER = False
+    assert webpack_public_path(request) == "/static/bundles/"
+
+
+def test_webpack_dev_server_host(settings, rf):
+    """Test webpack_dev_server_host()"""
+    request = rf.get("/", SERVER_NAME="invalid-dev-server1.local")
+    settings.WEBPACK_DEV_SERVER_HOST = "invalid-dev-server2.local"
+    assert webpack_dev_server_host(request) == "invalid-dev-server2.local"
+    settings.WEBPACK_DEV_SERVER_HOST = None
+    assert webpack_dev_server_host(request) == "invalid-dev-server1.local"
+
+
+def test_webpack_dev_server_url(settings, rf):
+    """Test webpack_dev_server_url()"""
+    settings.WEBPACK_DEV_SERVER_PORT = 7777
+    settings.WEBPACK_DEV_SERVER_HOST = "invalid-dev-server.local"
+    request = rf.get("/")
+    assert webpack_dev_server_url(request) == "http://invalid-dev-server.local:7777"


### PR DESCRIPTION
Updates `mitol-django-common` with some extra utilities and admin classes from downstream apps so this library is more usable for ocw-studio. This is a prereq for https://github.com/mitodl/ocw-studio/issues/9

This is all library code so a review and passing tests is sufficient.