### PR TITLE
Remove read/write req from credentials endpoint

### DIFF
--- a/mitol-django-digital-credentials/mitol/digitalcredentials/views.py
+++ b/mitol-django-digital-credentials/mitol/digitalcredentials/views.py
@@ -2,10 +2,7 @@
 import json
 
 from django.db import transaction
-from oauth2_provider.contrib.rest_framework import (
-    OAuth2Authentication,
-    TokenHasReadWriteScope,
-)
+from oauth2_provider.contrib.rest_framework import OAuth2Authentication, TokenHasScope
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -18,7 +15,7 @@ class DigitalCredentialRequestView(GenericAPIView):
     """Digital credential API views"""
 
     authentication_classes = [OAuth2Authentication]
-    permission_classes = [IsAuthenticated, TokenHasReadWriteScope]
+    permission_classes = [IsAuthenticated, TokenHasScope]
     required_scopes = ["digitalcredentials"]
     serializer_class = DigitalCredentialRequestSerializer
     lookup_field = "uuid"

--- a/mitol-django-digital-credentials/testapp/conftest.py
+++ b/mitol-django-digital-credentials/testapp/conftest.py
@@ -26,7 +26,7 @@ def learner_and_oauth2():
         token="1234567890",
         application=application,
         expires=now_in_utc() + timedelta(days=1),
-        scope="read write digitalcredentials",
+        scope="digitalcredentials",
     )
     return SimpleNamespace(
         learner=learner, application=application, access_token=access_token


### PR DESCRIPTION
This alters the permission classes on the view to not require read / write permissions, which we're no longer going to give to the digital credentials oauth client.

Tests passing should be adequate