### PR TITLE
Fix bug in request-digital-credential args

### DIFF
--- a/mitol-django-digital-credentials/mitol/digitalcredentials/mixins.py
+++ b/mitol-django-digital-credentials/mitol/digitalcredentials/mixins.py
@@ -32,7 +32,7 @@ class DigitalCredentialsRequestViewSetMixin(_Base):
         url_name="request_digital_credentials",
     )
     def request_digital_credential(
-        self, request: Request, pk=None
+        self, request: Request, *args: Any, **kwargs: Any
     ):  # pylint: disable=unused-argument
         """Action to create a digital credentials request"""
         credentialed_object = self.get_object()


### PR DESCRIPTION
If the route for the resource uses a `lookup_field` other than `pk` or otherwise has any additional url parameters the call will result in a 500 error. This fix just changes it to accept `*args, **kwargs` since it doesn't really care about any of those values.