### PR TITLE
Enhancements for configuration initialization

### DIFF
--- a/mitol-django-common/CHANGELOG.md
+++ b/mitol-django-common/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `mitol.common.envs.init_app_settings` to support namespace and site name configuration
+- Added `mitol.common.envs.import_settings_modules` to support dynamically importing a set of settings files 
+
 ## [0.5.0] - 2021-01-29
 
 ### Added

--- a/mitol-django-common/mitol/common/settings/base.py
+++ b/mitol-django-common/mitol/common/settings/base.py
@@ -1,0 +1,10 @@
+"""Common settings"""
+from mitol.common.envs import app_namespaced, get_string
+
+
+SITE_BASE_URL = get_string(
+    name=app_namespaced("BASE_URL"),
+    default=None,
+    description="Base url for the application in the format PROTOCOL://HOSTNAME[:PORT]",
+    required=True,
+)

--- a/mitol-django-common/testapp/settings/shared.py
+++ b/mitol-django-common/testapp/settings/shared.py
@@ -12,8 +12,13 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import os
 
-from mitol.common.settings.webpack import *
+from mitol.common.envs import import_settings_modules, init_app_settings
 
+
+init_app_settings(namespace="MITOL", site_name="MIT Open Learning Common Library")
+import_settings_modules(
+    globals(), "mitol.common.settings.base", "mitol.common.settings.webpack",
+)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 # multiple dinames to get up to mitol-django-mail/
@@ -119,7 +124,3 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
 STATIC_URL = "/static/"
-
-
-SITE_NAME = "Test app"
-SITE_BASE_URL = "http://127.0.0.1:8000/"

--- a/mitol-django-common/tests/test_envs.py
+++ b/mitol-django-common/tests/test_envs.py
@@ -203,3 +203,23 @@ def test_get_features(mocker):
     envs.env.reload()
     assert envs.get_features() == {"ABC": True, "DEF": False}
     assert envs.get_features("FLAG_") == {"GHI": False}
+
+
+def test_app_namespace():
+    """Verify that app_namespaced namespaces an environment variable"""
+    with pytest.raises(ImproperlyConfigured):
+        envs.app_namespaced("KEY")
+
+    envs.init_app_settings(namespace="PREFIX", site_name="")
+
+    assert envs.app_namespaced("KEY") == "PREFIX_KEY"
+
+
+def test_get_site_name():
+    """Verify that get_site_name returns the site name"""
+    with pytest.raises(ImproperlyConfigured):
+        envs.get_site_name()
+
+    envs.init_app_settings(namespace="", site_name="Site Name")
+
+    assert envs.get_site_name() == "Site Name"


### PR DESCRIPTION
This adds a couple of methods to make managing configurations a little easier:

- `import_settings_modules` - this dynamically imports settings modules in a similar way as django does, namely only importing uppercased constants. It also allows imports of modules in a nonstandard source order that would otherwise trigger lint errors or be reformatted via `isort`
- `init_app_settings` - initializes `Env` with the app's settings namespace and the site name so that other settings files can use them without needing to know where they are defined