### PR TITLE
Fix bugs in envs.init_app_settings

### DIFF
--- a/mitol-django-common/CHANGELOG.md
+++ b/mitol-django-common/CHANGELOG.md
@@ -6,11 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed a bug in `mitol.common.envs.init_app_settings` when `mitol.common.envs.validate` is called
+
 ## [0.6.0] - 2021-03-25
 
 ### Added
 - Added `mitol.common.envs.init_app_settings` to support namespace and site name configuration
-- Added `mitol.common.envs.import_settings_modules` to support dynamically importing a set of settings files 
+- Added `mitol.common.envs.import_settings_modules` to support dynamically importing a set of settings files
 
 ## [0.5.0] - 2021-01-29
 

--- a/mitol-django-common/mitol/common/envs.py
+++ b/mitol-django-common/mitol/common/envs.py
@@ -292,8 +292,13 @@ class EnvParser:
             namespace (str):
                 the app settings namespace
         """
-        self._configured_vars["APP_SETTINGS_NAMESPACE"] = namespace
-        self._configured_vars["SITE_NAME"] = site_name
+        self.get_string(
+            name="APP_SETTINGS_NAMESPACE",
+            default=namespace,
+            description="App environment variable namespace",
+            write_app_json=False,
+        )
+        self.get_string(name="SITE_NAME", default=site_name, description="Site name")
 
     def get_site_name(self):
         """Return the site name"""
@@ -302,7 +307,7 @@ class EnvParser:
             raise ImproperlyConfigured(
                 "Site name isn't set, add a call to init_app_settings()"
             )
-        return site_name
+        return site_name.value
 
     def app_namespaced(self, setting_key: str) -> str:
         """
@@ -315,7 +320,7 @@ class EnvParser:
             raise ImproperlyConfigured(
                 "App settings namespace isn't set, add a call to init_app_settings()"
             )
-        return f"{namespace}_{setting_key}"
+        return f"{namespace.value}_{setting_key}"
 
     get_string = var_parser(parse_str)
     get_bool = var_parser(parse_bool)

--- a/mitol-django-common/tests/test_envs.py
+++ b/mitol-django-common/tests/test_envs.py
@@ -210,7 +210,8 @@ def test_app_namespace():
     with pytest.raises(ImproperlyConfigured):
         envs.app_namespaced("KEY")
 
-    envs.init_app_settings(namespace="PREFIX", site_name="")
+    envs.init_app_settings(namespace="PREFIX", site_name="Site Name")
+    envs.validate()
 
     assert envs.app_namespaced("KEY") == "PREFIX_KEY"
 
@@ -220,6 +221,7 @@ def test_get_site_name():
     with pytest.raises(ImproperlyConfigured):
         envs.get_site_name()
 
-    envs.init_app_settings(namespace="", site_name="Site Name")
+    envs.init_app_settings(namespace="PREFIX", site_name="Site Name")
+    envs.validate()
 
     assert envs.get_site_name() == "Site Name"


### PR DESCRIPTION
This fixes an error that was happening:
```
celery_1  | Traceback (most recent call last):
celery_1  |   File "/usr/local/lib/python3.8/site-packages/celery/utils/dispatch/signal.py", line 288, in send
celery_1  |     response = receiver(signal=self, sender=sender, **named)
celery_1  |   File "/usr/local/lib/python3.8/site-packages/celery/fixups/django.py", line 84, in on_import_modules
celery_1  |     self.worker_fixup.validate_models()
celery_1  |   File "/usr/local/lib/python3.8/site-packages/celery/fixups/django.py", line 122, in validate_models
celery_1  |     self.django_setup()
celery_1  |   File "/usr/local/lib/python3.8/site-packages/celery/fixups/django.py", line 118, in django_setup
celery_1  |     django.setup()
celery_1  |   File "/usr/local/lib/python3.8/site-packages/django/__init__.py", line 24, in setup
celery_1  |     apps.populate(settings.INSTALLED_APPS)
celery_1  |   File "/usr/local/lib/python3.8/site-packages/django/apps/registry.py", line 122, in populate
celery_1  |     app_config.ready()
celery_1  |   File "/src/main/apps.py", line 14, in ready
celery_1  |     envs.validate()
celery_1  |   File "/usr/local/lib/python3.8/site-packages/mitol/common/envs.py", line 244, in validate
celery_1  |     if env_var.required and env_var.value in (None, ""):
celery_1  | AttributeError: 'str' object has no attribute 'required'
```

It also fixes the printing of missing vars when `envs.validate()` is called:
```
celery_1  |     raise ImproperlyConfigured(
celery_1  | django.core.exceptions.ImproperlyConfigured: The following settings are missing: MITXPRO_BASE_URL, EnvVariable(name='APP_SETTINGS_NAMESPACE', default='OCW_STUDIO', description='Namespace for app environment variables', required=False, dev_only=False, value='OCW_STUDIO', write_app_json=False)_BASE_URL, SOCIAL_AUTH_SAML_LOGIN_URL. You need to add these environment variables in .env file.
```

It's sufficient for tests to just pass here.