### PR TITLE
Add usage of SOCIAL_AUTH_SAML_IDP_ATTRIBUTE_NAME

### DIFF
--- a/mitol-django-authentication/CHANGELOG.md
+++ b/mitol-django-authentication/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Added usage of `SOCIAL_AUTH_SAML_IDP_ATTRIBUTE_NAME` to `SOCIAL_AUTH_SAML_ENABLED_IDPS`
+
 ## [1.0.0] - 2021-03-31
 
 ### Changed

--- a/mitol-django-authentication/mitol/authentication/settings/touchstone.py
+++ b/mitol-django-authentication/mitol/authentication/settings/touchstone.py
@@ -86,6 +86,7 @@ SOCIAL_AUTH_SAML_ENABLED_IDPS = {
         "attr_user_permanent_id": SOCIAL_AUTH_SAML_IDP_ATTRIBUTE_PERM_ID,
         "attr_username": SOCIAL_AUTH_SAML_IDP_ATTRIBUTE_PERM_ID,
         "attr_email": SOCIAL_AUTH_SAML_IDP_ATTRIBUTE_EMAIL,
+        "attr_full_name": SOCIAL_AUTH_SAML_IDP_ATTRIBUTE_NAME,
         "x509cert": SOCIAL_AUTH_SAML_IDP_X509,
     }
 }


### PR DESCRIPTION
Adds `SOCIAL_AUTH_SAML_IDP_ATTRIBUTE_NAME` to `SOCIAL_AUTH_SAML_IDP_ATTRIBUTE_NAME` so that SAML auth correctly pulls that attribute based on that setting.