### PR TITLE
Switched from using `id` -> `holder` for DC DIDs

### DIFF
--- a/mitol-django-digital-credentials/mitol/digitalcredentials/serializers.py
+++ b/mitol-django-digital-credentials/mitol/digitalcredentials/serializers.py
@@ -32,10 +32,10 @@ log = logging.getLogger(__name__)
 class DigitalCredentialIssueSerializer(Serializer):
     """Serializer for issuing digital credential"""
 
-    id = CharField(write_only=True)
+    holder = CharField(write_only=True)
 
-    def validate_id(self, value: str):
-        """Validate the id (DID)"""
+    def validate_holder(self, value: str):
+        """Validate the holder (DID)"""
         assert self.instance is not None
         learner = self.instance.learner
         learner_did, _ = LearnerDID.objects.get_or_create(
@@ -66,7 +66,7 @@ class DigitalCredentialIssueSerializer(Serializer):
         """Perform an update by consuming the credentials request"""
 
         # we associate the learner DID with the request's learner
-        did = cast(str, validated_data.get("id"))
+        did = cast(str, validated_data.get("holder"))
         learner_did = LearnerDID.objects.get(did_sha256=LearnerDID.sha256_hash_did(did))
 
         credential = build_credential(instance.credentialed_object, learner_did)

--- a/mitol-django-digital-credentials/tests/test_serializers.py
+++ b/mitol-django-digital-credentials/tests/test_serializers.py
@@ -48,7 +48,7 @@ def test_digital_credential_issue_serializer(learner, learner_did_exists):
         status=200,
     )
 
-    serializer = DigitalCredentialIssueSerializer(request, data={"id": did,})
+    serializer = DigitalCredentialIssueSerializer(request, data={"holder": did,})
     serializer.is_valid(raise_exception=True)
 
     result = serializer.save()
@@ -77,10 +77,10 @@ def test_digital_credential_issue_serializer_other_user_did(learner):
         status=200,
     )
     serializer = DigitalCredentialIssueSerializer(
-        request, data={"id": learner_did.did,}
+        request, data={"holder": learner_did.did,}
     )
     assert serializer.is_valid() is False
-    assert serializer.errors == {"id": ["DID is associated with someone else"]}
+    assert serializer.errors == {"holder": ["DID is associated with someone else"]}
 
 
 @responses.activate
@@ -97,7 +97,7 @@ def test_digital_credential_issue_serializer_presentation_verify_failed():
         status=400,
     )
     serializer = DigitalCredentialIssueSerializer(
-        request, data={"id": learner_did.did,}
+        request, data={"holder": learner_did.did,}
     )
     assert serializer.is_valid() is False
     assert serializer.errors == {
@@ -122,7 +122,7 @@ def test_digital_credential_issue_serializer_error(learner):
     )
 
     serializer = DigitalCredentialIssueSerializer(
-        request, data={"id": learner_did.did,}
+        request, data={"holder": learner_did.did,}
     )
     serializer.is_valid(raise_exception=True)
 

--- a/mitol-django-digital-credentials/tests/test_views.py
+++ b/mitol-django-digital-credentials/tests/test_views.py
@@ -42,7 +42,7 @@ def test_issue_credential(learner_and_oauth2):
             "digital-credentials:credentials-issue",
             kwargs={"uuid": credential_request.uuid},
         ),
-        {"id": "did:example:abc"},
+        {"holder": "did:example:abc"},
         HTTP_AUTHORIZATION=f"Bearer {learner_and_oauth2.access_token.token}",
     )
 
@@ -60,7 +60,7 @@ def test_issue_credential_anonymous():
             "digital-credentials:credentials-issue",
             kwargs={"uuid": credential_request.uuid},
         ),
-        {"id": "did:example:abc"},
+        {"holder": "did:example:abc"},
     )
     assert response.status_code == HTTPStatus.UNAUTHORIZED
 
@@ -75,7 +75,7 @@ def test_issue_credential_wrong_learner(learner_and_oauth2):
             "digital-credentials:credentials-issue",
             kwargs={"uuid": credential_request.uuid},
         ),
-        {"id": "did:example:abc"},
+        {"holder": "did:example:abc"},
         HTTP_AUTHORIZATION=f"Bearer {learner_and_oauth2.access_token.token}",
     )
     assert response.status_code == HTTPStatus.NOT_FOUND


### PR DESCRIPTION
This is the correct field we should be pulling the learner DID from.


Tests should pass.