### PR TITLE
Pass globals into init_app_settings

### DIFF
--- a/src/mitol/common/envs.py
+++ b/src/mitol/common/envs.py
@@ -285,21 +285,25 @@ class EnvParser:
             if key.startswith(prefix)
         }
 
-    def init_app_settings(self, *, namespace: str, site_name: str):
+    def init_app_settings(self, *, gbs: Dict, namespace: str, site_name: str):
         """
         Configure the app static settings
 
         Args:
+            gbs (dict):
+                A dictionary of global variables where we can set settings
             namespace (str):
                 the app settings namespace
+            site_name (str):
+                The name of the site
         """
-        self.get_string(
+        gbs["APP_SETTINGS_NAMESPACE"] = self.get_string(
             name="APP_SETTINGS_NAMESPACE",
             default=namespace,
             description="App environment variable namespace",
             write_app_json=False,
         )
-        self.get_string(name="SITE_NAME", default=site_name, description="Site name")
+        gbs["SITE_NAME"] = self.get_string(name="SITE_NAME", default=site_name, description="Site name")
 
     def get_site_name(self):
         """Return the site name"""

--- a/tests/mitol/common/test_envs.py
+++ b/tests/mitol/common/test_envs.py
@@ -209,10 +209,12 @@ def test_app_namespace():
     with pytest.raises(ImproperlyConfigured):
         envs.app_namespaced("KEY")
 
-    envs.init_app_settings(namespace="PREFIX", site_name="Site Name")
+    _globals = {}
+    envs.init_app_settings(gbs=_globals, namespace="PREFIX", site_name="Site Name")
     envs.validate()
 
     assert envs.app_namespaced("KEY") == "PREFIX_KEY"
+    assert _globals["APP_SETTINGS_NAMESPACE"] == "PREFIX"
 
 
 def test_get_site_name():
@@ -220,7 +222,9 @@ def test_get_site_name():
     with pytest.raises(ImproperlyConfigured):
         envs.get_site_name()
 
-    envs.init_app_settings(namespace="PREFIX", site_name="Site Name")
+    _globals = {}
+    envs.init_app_settings(gbs=_globals, namespace="PREFIX", site_name="Site Name")
     envs.validate()
 
     assert envs.get_site_name() == "Site Name"
+    assert _globals["SITE_NAME"] == "Site Name"

--- a/tests/testapp/settings/shared.py
+++ b/tests/testapp/settings/shared.py
@@ -14,14 +14,16 @@ import os
 
 import dj_database_url
 
-from mitol.common.envs import get_string, init_app_settings
+from mitol.common.envs import get_string, init_app_settings, import_settings_modules
 
-init_app_settings(namespace="MITOL", site_name="MIT Open Learning Common Library")
-
-from mitol.authentication.settings.touchstone import *  # noqa: E402,F401,F403
-from mitol.common.settings.base import *  # noqa: E402,F401,F403
-from mitol.common.settings.webpack import *  # noqa: E402,F401,F403
-from mitol.mail.settings.email import *  # noqa: E402,F401,F403
+init_app_settings(gbs=globals(), namespace="MITOL", site_name="MIT Open Learning Common Library")
+import_settings_modules(
+    globals(),
+    "mitol.common.settings.base",
+    "mitol.common.settings.webpack",
+    "mitol.mail.settings.email",
+    "mitol.authentication.settings.touchstone",
+)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))


### PR DESCRIPTION
Fixes #44 

This adds a required parameter to `init_app_settings` which takes `globals()` from `settings.py`. This will set a default value to `SITE_NAME` which fixes a bug in the mail app that expects `settings.SITE_NAME` to always exist.