### PR TITLE
Added support for added_attrs to render_bundle

### DIFF
--- a/src/mitol/authentication/apps.py
+++ b/src/mitol/authentication/apps.py
@@ -2,6 +2,8 @@
 import os
 
 from django.apps import AppConfig
+
+
 class AuthenticationApp(AppConfig):
     """Authentication AppConfig"""
 

--- a/src/mitol/authentication/settings/djoser_settings.py
+++ b/src/mitol/authentication/settings/djoser_settings.py
@@ -1,4 +1,5 @@
 from mitol.common.envs import get_string
+
 # Relative URL to be used by Djoser for the link in the password reset email
 # (see: http://djoser.readthedocs.io/en/stable/settings.html#password-reset-confirm-url)
 PASSWORD_RESET_CONFIRM_URL = "password_reset/confirm/{uid}/{token}/"
@@ -7,7 +8,7 @@ PASSWORD_RESET_CONFIRM_URL = "password_reset/confirm/{uid}/{token}/"
 MITOL_AUTHENTICATION_FROM_EMAIL = get_string(
     default="webmaster@localhost",
     name="MITOL_AUTHENTICATION_FROM_EMAIL",
-    description="E-mail to use for the from field"
+    description="E-mail to use for the from field",
 )
 
 MITOL_AUTHENTICATION_REPLY_TO_ADDRESS = get_string(
@@ -22,7 +23,9 @@ DJOSER = {
     "LOGOUT_ON_PASSWORD_CHANGE": False,
     "PASSWORD_RESET_CONFIRM_RETYPE": True,
     "PASSWORD_RESET_SHOW_EMAIL_NOT_FOUND": False,
-    "EMAIL": {"password_reset": "mitol.authentication.views.djoser_views.CustomPasswordResetEmail"},
+    "EMAIL": {
+        "password_reset": "mitol.authentication.views.djoser_views.CustomPasswordResetEmail"
+    },
     "SERIALIZERS": {
         "password_reset": "mitol.authentication.serializers.djoser_serializers.CustomSendEmailResetSerializer"
     },

--- a/src/mitol/authentication/views/djoser_views.py
+++ b/src/mitol/authentication/views/djoser_views.py
@@ -1,15 +1,16 @@
 """
 Custom views to override default djoser behaviours
 """
+from anymail.message import AnymailMessage
 from django.conf import settings
 from django.contrib.auth import update_session_auth_hash
 from django.core import mail as django_mail
+from djoser.email import PasswordResetEmail as DjoserPasswordResetEmail
 from djoser.utils import ActionViewMixin
 from djoser.views import UserViewSet
-from djoser.email import PasswordResetEmail as DjoserPasswordResetEmail
 from rest_framework import status
 from rest_framework.decorators import action
-from anymail.message import AnymailMessage
+
 from mitol.mail.api import render_email_templates, send_message
 
 
@@ -30,8 +31,9 @@ class CustomDjoserAPIView(UserViewSet, ActionViewMixin):
             update_session_auth_hash(self.request, self.request.user)
         return response
 
+
 class CustomPasswordResetEmail(DjoserPasswordResetEmail):
-    """Custom class to modify base functionality in Djoser's PasswordResetEmail class""" 
+    """Custom class to modify base functionality in Djoser's PasswordResetEmail class"""
 
     def send(self, to, *args, **kwargs):
         """
@@ -55,7 +57,7 @@ class CustomPasswordResetEmail(DjoserPasswordResetEmail):
             )
             msg.attach_alternative(html_body, "text/html")
             send_message(msg)
-    
+
     def get_context_data(self):
         """Adds base_url to the template context"""
         context = super().get_context_data()

--- a/src/mitol/common/CHANGELOG.md
+++ b/src/mitol/common/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added support for `added_attrs` argument for the `render_bundle` template tag.
+
 ## [2.0.0] - 2021-07-20
 
 ### Changed

--- a/src/mitol/common/templatetags/render_bundle.py
+++ b/src/mitol/common/templatetags/render_bundle.py
@@ -34,7 +34,9 @@ def _get_bundle(request: HttpRequest, bundle_name: str) -> Iterator[dict]:
 
 
 @register.simple_tag(takes_context=True)
-def render_bundle(context: Dict[str, Any], bundle_name: str) -> SafeText:
+def render_bundle(
+    context: Dict[str, Any], bundle_name: str, added_attrs: str = ""
+) -> SafeText:
     """
     Render the script tags for a Webpack bundle
 
@@ -45,25 +47,27 @@ def render_bundle(context: Dict[str, Any], bundle_name: str) -> SafeText:
     Args:
         context (dict): The context for rendering the template (includes request)
         bundle_name (str): The name of the bundle to render
+        added_attrs (str): Optional string of HTML attributes to add to the script/link tag
 
     Returns:
         django.utils.safestring.SafeText:
     """
     try:
         bundle = _get_bundle(context["request"], bundle_name)
-        return _render_tags(bundle)
+        return _render_tags(bundle, added_attrs)
     except OSError:
         # webpack-stats.json doesn't exist
         return mark_safe("")
 
 
-def _render_tags(bundle: Iterator[dict]) -> SafeText:
+def _render_tags(bundle: Iterator[dict], added_attrs: str = "") -> SafeText:
     """
     Outputs tags for template rendering.
     Adapted from webpack_loader.utils.get_as_tags and webpack_loader.templatetags.webpack_loader.
 
     Args:
         bundle (iterable of dict): The information about a webpack bundle
+        added_attrs (str): Optional string of HTML attributes to add to the script/link tag
 
     Returns:
         django.utils.safestring.SafeText: HTML for rendering bundles
@@ -73,14 +77,14 @@ def _render_tags(bundle: Iterator[dict]) -> SafeText:
     for chunk in bundle:
         if chunk["name"].endswith((".js", ".js.gz")):
             tags.append(
-                ('<script type="text/javascript" src="{}"></script>').format(
-                    chunk["url"]
+                ('<script type="text/javascript" src="{}" {} ></script>').format(
+                    chunk["url"], added_attrs
                 )
             )
         elif chunk["name"].endswith((".css", ".css.gz")):
             tags.append(
-                ('<link type="text/css" href="{}" rel="stylesheet" />').format(
-                    chunk["url"]
+                ('<link type="text/css" href="{}" rel="stylesheet" {} />').format(
+                    chunk["url"], added_attrs
                 )
             )
     return mark_safe("\n".join(tags))

--- a/tests/testapp/settings/shared.py
+++ b/tests/testapp/settings/shared.py
@@ -25,7 +25,7 @@ import_settings_modules(
     "mitol.common.settings.webpack",
     "mitol.mail.settings.email",
     "mitol.authentication.settings.touchstone",
-    "mitol.authentication.settings.djoser_settings"
+    "mitol.authentication.settings.djoser_settings",
 )
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)


### PR DESCRIPTION
Adds `added_attrs` to the `render_bundle` template tag. This is a port of the same implementation from xPro.

Tests passing should be adequate here.

Note: some additional files touched here due to running the code formatter.