### PR TITLE
fix: replacing url with re_path

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ dj-database-url>=0.5.0
 django-anymail>=6.0
 django-oauth-toolkit>=1.3.3
 django-webpack-loader>=0.7.0
-django>=2.2.12
+django>=2.2.12,<4.0
 djangorestframework>=3.0.0
 djoser==2.1.0
 html5lib>=1.1

--- a/src/mitol/mail/urls.py
+++ b/src/mitol/mail/urls.py
@@ -1,6 +1,6 @@
 """URL configurations for mail"""
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import re_path
 
 from mitol.mail.views import EmailDebuggerView
 
@@ -8,5 +8,5 @@ urlpatterns = []
 
 if getattr(settings, "MITOL_MAIL_ENABLE_EMAIL_DEBUGGER", False):  # pragma: no cover
     urlpatterns += [
-        url(r"^__emaildebugger__/$", EmailDebuggerView.as_view(), name="email-debugger")
+        re_path(r"^__emaildebugger__/$", EmailDebuggerView.as_view(), name="email-debugger")
     ]


### PR DESCRIPTION
Closes Issue https://github.com/mitodl/ol-django/issues/49

Github [workflow](https://github.com/mitodl/ol-django/actions/runs/1657309326) is failing with the following exception in urls.py of mail app/module: 

![image](https://user-images.githubusercontent.com/93309234/148210617-14c4f423-9234-42fb-9d3f-fee1697f07c8.png)

Since django.conf.urls was depreciated in django3.0 and removed in django4.0+ so this PR fixes this issue by replacing url with re_path