### PR TITLE
Fixing bug in CyberSource response validation code

### DIFF
--- a/src/mitol/payment_gateway/CHANGELOG.md
+++ b/src/mitol/payment_gateway/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # [Unreleased]
 
 ### Added
+- Bug fix for CyberSource processor validation 
+
+# [1.2.0] - 2022-02-02
+
+### Added
 - Added get_formatted_response helper to decode processor responses into a generic format
 - Added ProcessorResponse dataclass to provide a standard interface for processor responses
 

--- a/src/mitol/payment_gateway/api.py
+++ b/src/mitol/payment_gateway/api.py
@@ -367,10 +367,12 @@ class CyberSourcePaymentGateway(
         original transaction was sent, so we just reuse that process here, with
         some logic to pull the proper request data out depending on HTTP verb.
         """
-        if request.method == "GET":
-            passed_payload = request.query_params
+        if request.method == "POST":
+            passed_payload = getattr(request, "data", getattr(request, "POST", {}))
         else:
-            passed_payload = request.data
+            passed_payload = getattr(
+                request, "query_params", getattr(request, "GET", {})
+            )
 
         signature = self._generate_cybersource_sa_signature(passed_payload)
 


### PR DESCRIPTION
The perform_processor_response_validation method failed if the request passed to it wasn't a REST framework request. Updated to use the same logic as in decode_processor_response, which should also handle regular HttpRequest objects.