### PR TITLE
Adds hashing to the order username to get around CyberSource field limitations

### DIFF
--- a/src/mitol/payment_gateway/api.py
+++ b/src/mitol/payment_gateway/api.py
@@ -333,8 +333,7 @@ class CyberSourcePaymentGateway(
 
                 formatted_merchant_fields[f"merchant_defined_data{idx}"] = field_data
 
-        consumer_id_hasher = hashlib.sha256()
-        consumer_id = consumer_id_hasher.update(order.username).hexdigest()
+        consumer_id = hashlib.sha256(order.username.encode("ascii")).hexdigest()
 
         payload = {
             "access_key": settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY,

--- a/src/mitol/payment_gateway/api.py
+++ b/src/mitol/payment_gateway/api.py
@@ -333,10 +333,13 @@ class CyberSourcePaymentGateway(
 
                 formatted_merchant_fields[f"merchant_defined_data{idx}"] = field_data
 
+        consumer_id_hasher = hashlib.sha256()
+        consumer_id = consumer_id_hasher.update(order.username).hexdigest()
+
         payload = {
             "access_key": settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY,
             "amount": str(total),
-            "consumer_id": order.username,
+            "consumer_id": consumer_id,
             "currency": "USD",
             "locale": "en-us",
             **line_items,

--- a/src/mitol/payment_gateway/api.py
+++ b/src/mitol/payment_gateway/api.py
@@ -317,7 +317,13 @@ class CyberSourcePaymentGateway(
         self, order: Order, receipt_url: str, cancel_url: str, **kwargs
     ):
         """
-        This acts more as a coordinator for the internal methods in the class
+        This acts more as a coordinator for the internal methods in the class.
+
+        The username attached to the order is passed to CyberSource. However, it
+        won't accept an email address-like username (see
+        https://github.com/mitodl/mitxonline/issues/593), so this generates a
+        sha256 hash of the username to pass in to CyberSource. This hash isn't
+        stored anywhere.
         """
 
         (line_items, total) = self._generate_line_items(order.items)
@@ -387,6 +393,10 @@ class CyberSourcePaymentGateway(
         out of the response and convert it back to an Order and a set of
         CartItems. (Not all payment processor APIs may support this, so this
         is just defined for the CyberSource one.)
+
+        Note that the username that is returned by CyberSource will be the
+        sha256 hash of the username that was originally passed in, and *not* the
+        actual username.
 
         Args:
             response: Dict; the data from the response

--- a/tests/mitol/payment_gateway/test_cybersource.py
+++ b/tests/mitol/payment_gateway/test_cybersource.py
@@ -61,8 +61,7 @@ def generate_test_cybersource_payload(order, cartitems, transaction_uuid):
         test_line_items[f"item_{idx}_tax_amount"] = str(line.taxable)
         test_line_items[f"item_{idx}_unit_price"] = str(line.unitprice)
 
-    consumer_id_hasher = hashlib.sha256()
-    consumer_id = consumer_id_hasher.update(order.username).hexdigest()
+    consumer_id = hashlib.sha256(order.username.encode("ascii")).hexdigest()
 
     test_payload = {
         "access_key": settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY,

--- a/tests/mitol/payment_gateway/test_cybersource.py
+++ b/tests/mitol/payment_gateway/test_cybersource.py
@@ -1,6 +1,6 @@
+import hashlib
 import json
 import os
-import hashlib
 from dataclasses import dataclass
 from typing import Dict
 

--- a/tests/mitol/payment_gateway/test_cybersource.py
+++ b/tests/mitol/payment_gateway/test_cybersource.py
@@ -1,5 +1,6 @@
 import json
 import os
+import hashlib
 from dataclasses import dataclass
 from typing import Dict
 
@@ -60,10 +61,13 @@ def generate_test_cybersource_payload(order, cartitems, transaction_uuid):
         test_line_items[f"item_{idx}_tax_amount"] = str(line.taxable)
         test_line_items[f"item_{idx}_unit_price"] = str(line.unitprice)
 
+    consumer_id_hasher = hashlib.sha256()
+    consumer_id = consumer_id_hasher.update(order.username).hexdigest()
+
     test_payload = {
         "access_key": settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY,
         "amount": str(test_total),
-        "consumer_id": order.username,
+        "consumer_id": consumer_id,
         "currency": "USD",
         "locale": "en-us",
         **test_line_items,


### PR DESCRIPTION
Partial fix for https://github.com/mitodl/mitxonline/issues/593 

This patch hashes the username provided before sending the payment request to CyberSource. 

The username on the order is provided as part of the payload used to start a payment session with CyberSource (as the `consumer_id` field). Per the integration guide, this field accepts up to 100 alphanumeric and punctuation characters. However, it specifically fails if you attempt to pass in something that looks like an email address. (You can pass in a string with an `@` symbol or a `.` but not both.) To work around this, the system will now generate a `sha256` hash of the username data and passes that along as a 64-character hexadecimal string. 