### PR TITLE
Updates version and changelog for payment_gateway

### DIFF
--- a/src/mitol/payment_gateway/CHANGELOG.md
+++ b/src/mitol/payment_gateway/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [1.4.0] - 2022-06-10
+## [Unreleased]
+
+## [1.4.0] - 2022-06-10
 
 ### Changed
 - Adds hashing to the order username to get around CyberSource field limitations
 
-# [1.2.2] - 2022-02-24
+## [1.2.2] - 2022-02-24
 
 ### Changed
 - Bump `mitol-django-common` to `2.2.0`.
@@ -17,23 +19,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Bug fix for CyberSource order extraction
 
-# [1.2.1] - 2022-02-11
+## [1.2.1] - 2022-02-11
 
 ### Added
 - Bug fix for CyberSource processor validation 
 
-# [1.2.0] - 2022-02-02
+## [1.2.0] - 2022-02-02
 
 ### Added
 - Added get_formatted_response helper to decode processor responses into a generic format
 - Added ProcessorResponse dataclass to provide a standard interface for processor responses
 
-# [1.1.0] - 2022-01-24
+## [1.1.0] - 2022-01-24
 
 ### Added
 - Added validate_processor_response helper for creating authentication classes
 
-# [1.0.0] - 2022-01-20
+## [1.0.0] - 2022-01-20
 
 ### Added
 - Added `mitol-django-payment_gateway` app

--- a/src/mitol/payment_gateway/CHANGELOG.md
+++ b/src/mitol/payment_gateway/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Unreleased] - 2022-02-24
+# [1.4.0] - 2022-06-10
+
+### Changed
+- Adds hashing to the order username to get around CyberSource field limitations
+
+# [1.2.2] - 2022-02-24
 
 ### Changed
 - Bump `mitol-django-common` to `2.2.0`.

--- a/src/mitol/payment_gateway/__init__.py
+++ b/src/mitol/payment_gateway/__init__.py
@@ -1,5 +1,5 @@
 """ mitol.openedx """
 default_app_config = "mitol.payment_gateway.apps.PaymentGatewayApp"
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 __distributionname__ = "mitol-django-payment-gateway"


### PR DESCRIPTION
Updates the version number for payment_gateway to 1.4.0 and updates the changelog appropriately. There are no functional changes in this request. 