### PR TITLE
fix: run linting on both src and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: sudo apt-get install -y libxmlsec1-dev
 
       - name: Lints
-        run: ./pants lint "tests/mitol/${{ matrix.app-name }}:"
+        run: ./pants lint "src/mitol/${{ matrix.app-name }}:" "tests/mitol/${{ matrix.app-name }}:"
 
       # - name: Typecheck
       #   run: ./pants typecheck "tests/mitol/${{ matrix.app-name }}:"

--- a/src/mitol/common/decorators.py
+++ b/src/mitol/common/decorators.py
@@ -1,5 +1,4 @@
 import random
-from django.conf import settings
 from functools import wraps
 
 from django.utils.cache import get_max_age, patch_cache_control

--- a/src/mitol/google_sheets/api.py
+++ b/src/mitol/google_sheets/api.py
@@ -10,7 +10,6 @@ from urllib.parse import urljoin
 import pygsheets
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.db import transaction
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
@@ -24,15 +23,8 @@ from mitol.google_sheets.constants import (
     GOOGLE_TOKEN_URI,
     REQUIRED_GOOGLE_API_SCOPES,
 )
-from mitol.google_sheets.models import (
-    FileWatchRenewalAttempt,
-    GoogleApiAuth,
-    GoogleFileWatch,
-)
-from mitol.google_sheets.utils import (
-    format_datetime_for_google_timestamp,
-    google_timestamp_to_datetime,
-)
+from mitol.google_sheets.models import GoogleApiAuth
+from mitol.google_sheets.utils import format_datetime_for_google_timestamp
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
#### Description:
Currently, linting just runs for the test directories of the applications, which means if there are linting issues including (flake8, isort) in the src directories they will not fail the CI as they will for the tests directory.

#### Related ticket:
None

#### What this PR does?

Updates the CI script to run the linting on src and test directories.

#### How to test?
- Majorly just check that the CI passes
- In addition, Since there are some fixes for existing linting errors in src which are unsued imports or iSort so just make sure that the removed imports are the right ones.