### PR TITLE
add create refund request operation to payment_gateway

### DIFF
--- a/src/mitol/common/decorators.py
+++ b/src/mitol/common/decorators.py
@@ -1,7 +1,6 @@
 import random
 from functools import wraps
 
-from django.conf import settings
 from django.utils.cache import get_max_age, patch_cache_control
 
 

--- a/src/mitol/google_sheets/sheet_handler_api.py
+++ b/src/mitol/google_sheets/sheet_handler_api.py
@@ -7,9 +7,9 @@ from django.conf import settings
 from django.db import transaction
 from django.utils.functional import cached_property
 
-from mitol.common.utils.collections import group_into_dict, item_at_index_or_none
+from mitol.common.utils.collections import group_into_dict
 from mitol.google_sheets.api import get_authorized_pygsheets_client
-from mitol.google_sheets.constants import GOOGLE_API_TRUE_VAL, GOOGLE_SHEET_FIRST_ROW
+from mitol.google_sheets.constants import GOOGLE_SHEET_FIRST_ROW
 from mitol.google_sheets.utils import (
     ResultType,
     RowResult,

--- a/src/mitol/google_sheets_refunds/api.py
+++ b/src/mitol/google_sheets_refunds/api.py
@@ -7,12 +7,7 @@ from django.contrib.auth import get_user_model
 from mitol.common.utils.datetime import now_in_utc
 from mitol.google_sheets.exceptions import SheetRowParsingException
 from mitol.google_sheets.sheet_handler_api import GoogleSheetsChangeRequestHandler
-from mitol.google_sheets.utils import (
-    ResultType,
-    RowResult,
-    clean_sheet_value,
-    parse_sheet_date_only_str,
-)
+from mitol.google_sheets.utils import ResultType, RowResult
 from mitol.google_sheets_refunds.hooks import get_plugin_manager
 from mitol.google_sheets_refunds.models import RefundRequest
 from mitol.google_sheets_refunds.utils import RefundRequestRow, refund_sheet_config

--- a/src/mitol/google_sheets_refunds/utils.py
+++ b/src/mitol/google_sheets_refunds/utils.py
@@ -117,9 +117,9 @@ class RefundRequestSheetConfig(
         self.non_input_column_indices = set(
             # Response ID column
             [self.FORM_RESPONSE_ID_COL]
-            +
-            # Every column from the finance columns to the end of the row
-            list(range(8, self.num_columns))
+            + list(  # Every column from the finance columns to the end of the row
+                range(8, self.num_columns)
+            )
         )
         self.sheet_file_id = settings.MITOL_GOOGLE_SHEETS_ENROLLMENT_CHANGE_SHEET_ID
 

--- a/src/mitol/payment_gateway/README.md
+++ b/src/mitol/payment_gateway/README.md
@@ -74,18 +74,17 @@ The custom data (merchant_fields) should be a list of items to pass along with t
 **Refund Code Example:**
 
 ```python
-from mitol.payment_gateway.api import Refund, PaymentGateway
-    
-     refund_request = Refund(
-         transaction_id=transaction_id,     # You can find this in any successful payment's response JSON
-         refund_amount=order_amount,        # The amount to be refunded
-         refund_currency=order_currency,    # Currency to be used for the refund
-     )
-    
+from mitol.payment_gateway.api import PaymentGateway
+      # Create a Refund request object to perform operations on
+      refund_gateway_request = PaymentGateway.create_refund_request(
+          ECOMMERCE_DEFAULT_PAYMENT_GATEWAY,
+          transaction_dict  # Ideally this dict should have transaction_id, req_amount, req_currency
+      )
+
       # Call start_refund from PaymentGateway with the Refund object you just created above 
       response = PaymentGateway.start_refund(
           ECOMMERCE_DEFAULT_PAYMENT_GATEWAY,    # Default Gateway to be used for processing e.g. CyberSource
-          refund_request,
+          refund_gateway_request,
       )
 
 

--- a/src/mitol/payment_gateway/exceptions.py
+++ b/src/mitol/payment_gateway/exceptions.py
@@ -2,6 +2,8 @@
 
 
 class RefundDuplicateException(Exception):
+    """Exception class for Duplicate Refund requests"""
+
     def __init__(
         self,
         refund_reason_code,
@@ -16,5 +18,18 @@ class RefundDuplicateException(Exception):
         self.body = response_body
 
         if message is None:
-            self.message = f"There was an error in Refund API for transaction_id={self.transaction_id} with ReasonCode={self.reason_code}"
+            message = f"There was an error in Refund API for transaction_id={self.transaction_id} with ReasonCode={self.reason_code}"
+        super().__init__(message)
+
+
+class InvalidTransactionException(Exception):
+    """Exception class for Invalid transaction data"""
+
+    def __init__(
+        self,
+        message=None,
+    ):
+        if message is None:
+            message = "The provided transaction dictionary is invalid. Please check it contains transaction_id, req_amount, req_currency"
+
         super().__init__(message)


### PR DESCRIPTION
#### What this PR does:

- Adds a new method on the PaymentGateway to create Refund requests out of the payment transaction dictionary returned by CyberSource on successful payment.
- Fixes linting issues
- Updates ib README

#### Related ticket:
Created in response to https://github.com/mitodl/mitxonline/pull/599#discussion_r915422235


#### How to test?
You can check the README to test