### PR TITLE
Sheets Refunds: Instead of order id use order reference number

### DIFF
--- a/src/mitol/google_sheets/README.md
+++ b/src/mitol/google_sheets/README.md
@@ -160,12 +160,14 @@ Update your .env file with the settings listed above, that begin with `MITOL_GOO
 Your local xPRO needs permissions to be able to read/write to your Drive. This can
 be done via OAuth with the help of ngrok.
 
-1. Run ngrok using the nginx port for this app: `ngrok http 8053`
-2. Begin domain verification
+1. Run ngrok using the nginx port for this app: `ngrok http 8013`
+2. Visit the credential section of the Google Developer Console: https://console.developers.google.com/apis/credentials,
+select your auth client and update `Authorized redirect URIs` if it changed.
+3. Begin domain verification
     1. Visit Webmasters home: https://www.google.com/webmasters/verification/home?hl=en
     1. Enter the **HTTPS** URL that ngrok is exposing (use the full URL including the protocol)
     1. Select Alternate Methods > HTML Tag auth, and copy the "content" attribute value from tag (just the value, not the full HTML tag)
-3. Update your .env
+4. Update your .env
  ```dotenv
 <your_app_name>_BASE_URL=<Full ngrok HTTPS URL, including protocol>
 GOOGLE_DOMAIN_VERIFICATION_TAG_VALUE=<"content" attribute value from step 2.iii>

--- a/src/mitol/google_sheets_refunds/utils.py
+++ b/src/mitol/google_sheets_refunds/utils.py
@@ -27,7 +27,7 @@ class RefundRequestRow:
         zendesk_ticket_no,
         requester_email,
         product_id,
-        order_id,
+        order_ref_num,
         order_type,
         finance_email,
         finance_approve_date,
@@ -44,7 +44,7 @@ class RefundRequestRow:
         self.zendesk_ticket_no = zendesk_ticket_no
         self.requester_email = requester_email
         self.product_id = product_id
-        self.order_id = order_id
+        self.order_ref_num = order_ref_num
         self.order_type = order_type
         self.finance_email = finance_email
         self.finance_approve_date = finance_approve_date
@@ -76,7 +76,7 @@ class RefundRequestRow:
                 zendesk_ticket_no=raw_row_data[3],
                 requester_email=raw_row_data[4],
                 product_id=raw_row_data[5],
-                order_id=int(raw_row_data[6]),
+                order_ref_num=raw_row_data[6],
                 order_type=raw_row_data[7],
                 finance_email=raw_row_data[8],
                 finance_approve_date=parse_sheet_date_only_str(raw_row_data[9]),

--- a/tests/mitol/google_sheets_refunds/refund_requests.csv
+++ b/tests/mitol/google_sheets_refunds/refund_requests.csv
@@ -2,4 +2,4 @@ Id,Request Date ,Learner Email,Zendesk Ticket,Refund Approved By,Course Run or P
 8,6/26/2019,student1@mit.edu,31999,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,40, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,
 9,6/26/2019,student2@mit.edu,31998,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,31, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,
 10,6/26/2019,student3@mit.edu,31997,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,35, ,staff2@mit.edu,7/2/19,, ,engineer@mit.edu,7/5/2019,,
-9,6/26/2019,student2@mit.edu,31997,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,32c, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,
+9,6/26/2019,student2@mit.edu,31997,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-32, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,

--- a/tests/mitol/google_sheets_refunds/test_api.py
+++ b/tests/mitol/google_sheets_refunds/test_api.py
@@ -148,8 +148,8 @@ def test_full_sheet_process(db, settings, mocker, pygsheets_fixtures, request_cs
     mock_get_plugin_manager.assert_called_once()
 
     result = handler.process_sheet()
-    expected_processed_rows = {4, 5}
-    expected_failed_rows = {6, 7}
+    expected_processed_rows = {4, 5, 7}
+    expected_failed_rows = {6}
     assert ResultType.PROCESSED.value in result
     assert (
         set(result[ResultType.PROCESSED.value]) == expected_processed_rows


### PR DESCRIPTION
Fix https://github.com/mitodl/mitxonline/pull/847

When processing refunds use parse the reference number of an Order.