### PR TITLE
Adding TRANSMITTED as a valid status

### DIFF
--- a/src/mitol/payment_gateway/api.py
+++ b/src/mitol/payment_gateway/api.py
@@ -750,12 +750,13 @@ class CyberSourcePaymentGateway(
             return ProcessorResponse.STATE_ACCEPTED
         elif decision == "DECLINE":
             return ProcessorResponse.STATE_DECLINED
-            # maybe should log here? this is a straight-up something went wrong between the app and the processor state
         elif decision == "CANCEL":
             return ProcessorResponse.STATE_CANCELLED
         elif decision == "REVIEW":
             return ProcessorResponse.STATE_REVIEW
         elif decision == "PENDING":
             return ProcessorResponse.STATE_PENDING
+        elif decision == "TRANSMITTED":
+            return ProcessorResponse.STATE_TRANSMITTED
 
         return ProcessorResponse.STATE_ERROR

--- a/src/mitol/payment_gateway/api.py
+++ b/src/mitol/payment_gateway/api.py
@@ -123,6 +123,8 @@ class ProcessorResponse:
     STATE_DUPLICATE = "DUPLICATE_REQUEST"
     # The possible state for a successful refund is always `PENDING`
     STATE_PENDING = "PENDING"
+    # CyberSource uses this status - it seems to be basically ACCEPT but maybe gets hit when the webhook activates?
+    STATE_TRANSMITTED = "TRANSMITTED"
 
 
 class PaymentGateway(abc.ABC):


### PR DESCRIPTION
This just adds `TRANSMITTED` as a constant to the `PaymentResponse `class so it can be used elsewhere. CyberSource seems to use this response code. 