### PR TITLE
fix: change username encoding from ascii to utf-8

### DIFF
--- a/src/mitol/payment_gateway/api.py
+++ b/src/mitol/payment_gateway/api.py
@@ -453,7 +453,7 @@ class CyberSourcePaymentGateway(
 
                 formatted_merchant_fields[f"merchant_defined_data{idx}"] = field_data
 
-        consumer_id = hashlib.sha256(order.username.encode("ascii")).hexdigest()
+        consumer_id = hashlib.sha256(order.username.encode("utf-8")).hexdigest()
 
         payload = {
             "access_key": settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY,

--- a/tests/mitol/payment_gateway/api/test_cybersource.py
+++ b/tests/mitol/payment_gateway/api/test_cybersource.py
@@ -88,7 +88,7 @@ def generate_test_cybersource_payload(order, cartitems, transaction_uuid):
         test_line_items[f"item_{idx}_tax_amount"] = str(line.taxable)
         test_line_items[f"item_{idx}_unit_price"] = str(line.unitprice)
 
-    consumer_id = hashlib.sha256(order.username.encode("ascii")).hexdigest()
+    consumer_id = hashlib.sha256(order.username.encode("utf-8")).hexdigest()
 
     test_payload = {
         "access_key": settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY,


### PR DESCRIPTION
#### Related ticket:

https://github.com/mitodl/mitxonline/issues/1162

#### What this PR does?
- switches username string encoding from `ascii` to `utf-8`
- ascii wasn't able to encode with special characters that are non-ascii. e.g. `á`


#### How should this be tested?
- You can follow the testing steps mentioned in the associated ticket.
- Over the top, You should have a user with a special character in his/her username e.g. `ArslánTuser5`. The user should successfully be able to complete checkout process
- I also tested it with username having `@` and or `.` and the payment was successful since we are hasing the text overall.

A few examples with this change:

- `"ArslánTuser5".encode("utf-8")` would now return `b'Arsl\xc3\xa1nTuser5'`
- `"arslan".encode("urf-8")` and `"arslan".encode("ascii")` both return `b'arslan'`
