### PR TITLE
Update github action usages and simplify matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,11 @@
 name: CI
 on: [push]
 jobs:
-  list_applications:
-
-    runs-on: ubuntu-latest
-    steps:
-      # dynamically determine application names so we automatically pick up new apps
-      - uses: actions/checkout@v2
-
-      - name: list all monorepo applications
-        id: set-app-names
-        run: |
-          cd src/mitol
-          APP_NAMES=$(ls -d */ | sed 's#/##' | jq -R -s -c 'gsub("-";"_") | split("\n") | map(select(length > 0))')
-          echo "::set-output name=app-names::${APP_NAMES}"
-
-    # save the list into the outputs
-    outputs:
-      app-names: ${{ steps.set-app-names.outputs.app-names }}
-
   tests:
     runs-on: ubuntu-latest
-    needs: list_applications
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        app-name: ${{ fromJson(needs.list_applications.outputs.app-names) }}
 
     # Service containers to run
     services:
@@ -44,10 +24,10 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -58,13 +38,13 @@ jobs:
         run: sudo apt-get install -y libxmlsec1-dev
 
       - name: Lints
-        run: ./pants lint "src/mitol/${{ matrix.app-name }}:" "tests/mitol/${{ matrix.app-name }}:"
+        run: './pants lint ::'
 
       # - name: Typecheck
-      #   run: ./pants typecheck "tests/mitol/${{ matrix.app-name }}:"
+      #   run: './pants typecheck ::'
 
       - name: Tests
-        run: ./pants test "tests/mitol/${{ matrix.app-name }}:"
+        run: './pants test ::'
 
       # - name: Upload coverage to CodeCov
       #   uses: codecov/codecov-action@v1
@@ -77,15 +57,15 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
     # extract the app name out of the tag's ref value
     - id: get-app-name
-      uses: actions/github-script@v3
+      uses: actions/github-script@v6
       with:
         script: |
           const appName = context.ref.match(/refs\/tags\/([a-z\-]+)\/v\S+$/)[1]

--- a/build-support/bin/release.py
+++ b/build-support/bin/release.py
@@ -116,7 +116,7 @@ def main() -> None:
 
     # checkout the main branch
     repo = Repo(".")
-    # repo.heads.main.checkout()
+    repo.heads.main.checkout()
 
     version_filename = join(app_dir, "__init__.py")
     metadata = update_init_py(args, version_filename)
@@ -127,7 +127,7 @@ def main() -> None:
     )
 
     # commit the changes and tag it
-    print("Commiting")
+    print("Committing")
     repo.index.add(
         [
             changelog_filename,

--- a/src/mitol/hubspot_api/CHANGELOG.md
+++ b/src/mitol/hubspot_api/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
-## [0.1.0] - 2022-07-22
+## [1.0.0] - 2022-07-22
 
 ### Added
 - Added `mitol.hubspot_api` Hubspot API library.

--- a/src/mitol/hubspot_api/__init__.py
+++ b/src/mitol/hubspot_api/__init__.py
@@ -1,5 +1,5 @@
 """ mitol.hubspot_api """
 default_app_config = "mitol.hubspot_api.apps.HubspotApiApp"
 
-__version__ = "1.0.1"
-__distributionname__ = "mitol-django-hubspot_api"
+__version__ = "1.0.0"
+__distributionname__ = "mitol-django-hubspot-api"


### PR DESCRIPTION
- Updates github action usage to newer versions that use node16 to get rid of warnings (these will eventually break anyway). See: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- Removes the partitioning of the test runs on a per-app basis - this is getting a bit unweildy as the count of apps increases and it is making tests take longer over time. Every time we add an app it causes 3 more actions (1 for each python version we're testing ) to be run. We're at ~8 minutes now, up from 2 minutes when this repo had 1 app. This change lowers that to 6 minutes and it should hopefully not increase as much over time.

Additionally, since the goal here is to fix the `hubspot_api` release:

- Fixed the value of `__distribution__` to
-  remove underscore in favor of `-` so that future releases work


### How do I verify?

The tests should pass here.