### PR TITLE
Updates Google sheets code to filter out rows that have the Ignore flag set

### DIFF
--- a/src/mitol/google_sheets_refunds/api.py
+++ b/src/mitol/google_sheets_refunds/api.py
@@ -121,15 +121,15 @@ class RefundRequestHandler(GoogleSheetsChangeRequestHandler):
             message=message,
         )
 
-    def _int_filter_row(self, idx, row):
-        parsed_data = RefundRequestRow.parse_raw_data(idx, row)
-
-        return not parsed_data.skip_row 
+    def _int_filter_row(self, row_tuple):
+        parsed_data = RefundRequestRow.parse_raw_data(*row_tuple)
+        breakpoint()
+        return not parsed_data.skip_row
 
     def filter_ignored_rows(self, enumerated_rows):
         """
-        Filters skippable rows in the sheet. A row is skippable if either of these conditions is met:
-        - 
+        Filters skippable rows in the sheet. A row is skippable if these conditions is met:
+        - Ignore 
 
         Args:
             enumerated_rows (Iterable[Tuple[int, List[str]]]): Row indices paired with a list of strings
@@ -138,4 +138,4 @@ class RefundRequestHandler(GoogleSheetsChangeRequestHandler):
         Returns:
             Iterable[Tuple[int, List[str]]]: Iterable of data rows without the ones that should be ignored.
         """
-        return filter(self.filter_ignored_rows, enumerated_rows)
+        return filter(self._int_filter_row, enumerated_rows)

--- a/src/mitol/google_sheets_refunds/api.py
+++ b/src/mitol/google_sheets_refunds/api.py
@@ -120,3 +120,22 @@ class RefundRequestHandler(GoogleSheetsChangeRequestHandler):
             result_type=result_type,
             message=message,
         )
+
+    def _int_filter_row(self, idx, row):
+        parsed_data = RefundRequestRow.parse_raw_data(idx, row)
+
+        return not parsed_data.skip_row 
+
+    def filter_ignored_rows(self, enumerated_rows):
+        """
+        Filters skippable rows in the sheet. A row is skippable if either of these conditions is met:
+        - 
+
+        Args:
+            enumerated_rows (Iterable[Tuple[int, List[str]]]): Row indices paired with a list of strings
+                representing the data in each row
+
+        Returns:
+            Iterable[Tuple[int, List[str]]]: Iterable of data rows without the ones that should be ignored.
+        """
+        return filter(self.filter_ignored_rows, enumerated_rows)

--- a/src/mitol/google_sheets_refunds/api.py
+++ b/src/mitol/google_sheets_refunds/api.py
@@ -125,7 +125,11 @@ class RefundRequestHandler(GoogleSheetsChangeRequestHandler):
         """Performs row filtering according to the rules noted in filter_ignored_rows"""
         try:
             parsed_data = RefundRequestRow.parse_raw_data(*row_tuple)
-            return not parsed_data.skip_row
+            return not (
+                parsed_data.skip_row
+                or parsed_data.refund_complete_date is not None
+                or len(parsed_data.errors) > 0
+            )
         except Exception:
             return True
 

--- a/src/mitol/google_sheets_refunds/api.py
+++ b/src/mitol/google_sheets_refunds/api.py
@@ -122,14 +122,17 @@ class RefundRequestHandler(GoogleSheetsChangeRequestHandler):
         )
 
     def _int_filter_row(self, row_tuple):
-        parsed_data = RefundRequestRow.parse_raw_data(*row_tuple)
-        breakpoint()
-        return not parsed_data.skip_row
+        """Performs row filtering according to the rules noted in filter_ignored_rows"""
+        try:
+            parsed_data = RefundRequestRow.parse_raw_data(*row_tuple)
+            return not parsed_data.skip_row
+        except Exception:
+            return True
 
     def filter_ignored_rows(self, enumerated_rows):
         """
         Filters skippable rows in the sheet. A row is skippable if these conditions is met:
-        - Ignore 
+        - Ignore flag is set to TRUE
 
         Args:
             enumerated_rows (Iterable[Tuple[int, List[str]]]): Row indices paired with a list of strings

--- a/src/mitol/google_sheets_refunds/api.py
+++ b/src/mitol/google_sheets_refunds/api.py
@@ -126,9 +126,7 @@ class RefundRequestHandler(GoogleSheetsChangeRequestHandler):
         try:
             parsed_data = RefundRequestRow.parse_raw_data(*row_tuple)
             return not (
-                parsed_data.skip_row
-                or parsed_data.refund_complete_date is not None
-                or len(parsed_data.errors) > 0
+                parsed_data.skip_row or parsed_data.refund_complete_date is not None
             )
         except Exception:
             return True

--- a/tests/mitol/google_sheets_refunds/refund_requests.csv
+++ b/tests/mitol/google_sheets_refunds/refund_requests.csv
@@ -3,3 +3,4 @@ Id,Request Date ,Learner Email,Zendesk Ticket,Refund Approved By,Course Run or P
 9,6/26/2019,student2@mit.edu,31998,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,31, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,
 10,6/26/2019,student3@mit.edu,31997,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,35, ,staff2@mit.edu,7/2/19,, ,engineer@mit.edu,7/5/2019,,
 9,6/26/2019,student2@mit.edu,31997,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-32, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,
+10,6/26/2019,student4@mit.edu,31337,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-32, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,TRUE

--- a/tests/mitol/google_sheets_refunds/refund_requests.csv
+++ b/tests/mitol/google_sheets_refunds/refund_requests.csv
@@ -3,4 +3,6 @@ Id,Request Date ,Learner Email,Zendesk Ticket,Refund Approved By,Course Run or P
 9,6/26/2019,student2@mit.edu,31998,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,31, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,
 10,6/26/2019,student3@mit.edu,31997,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,35, ,staff2@mit.edu,7/2/19,, ,engineer@mit.edu,7/5/2019,,
 9,6/26/2019,student2@mit.edu,31997,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-32, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,
-10,6/26/2019,student4@mit.edu,31337,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-32, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,TRUE
+11,6/26/2019,student4@mit.edu,31337,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-32, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,TRUE
+12,6/26/2019,student8@mit.edu,31337,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-32, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,error row,
+13,6/26/2019,student8@mit.edu,31337,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-35, ,staff2@mit.edu,7/2/2019,, ,,,,

--- a/tests/mitol/google_sheets_refunds/refund_requests.csv
+++ b/tests/mitol/google_sheets_refunds/refund_requests.csv
@@ -1,8 +1,10 @@
 Id,Request Date ,Learner Email,Zendesk Ticket,Refund Approved By,Course Run or Program ID,Order Number,Type,Transaction Reverse By,Refund Date,Notes/Amt. Refunded,Auth Code,Order Updated By,Order Completed Date,Errors,Ignore?
 8,6/26/2019,student1@mit.edu,31999,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,40, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,
-9,6/26/2019,student2@mit.edu,31998,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,31, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,
+9,6/26/2019,student2@mit.edu,31998,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,31, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,,,
 10,6/26/2019,student3@mit.edu,31997,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,35, ,staff2@mit.edu,7/2/19,, ,engineer@mit.edu,7/5/2019,,
-9,6/26/2019,student2@mit.edu,31997,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-32, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,
+9,6/26/2019,student2@mit.edu,31997,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-32, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,,,
 11,6/26/2019,student4@mit.edu,31337,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-32, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,,TRUE
 12,6/26/2019,student8@mit.edu,31337,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-32, ,staff2@mit.edu,7/2/2019,, ,engineer@mit.edu,7/5/2019,error row,
 13,6/26/2019,student8@mit.edu,31337,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-35, ,staff2@mit.edu,7/2/2019,, ,,,,
+14,6/26/2019,student8@mit.edu,31337,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-32, ,staff2@mit.edu,7/2/2019,, ,,,error row but no date,
+15,6/26/2019,student8@mit.edu,31337,staff@mit.edu,course-v1:edX+DemoX+Demo_Course,order-reference-number-32, ,staff2@mit.edu,7/2/2019,, ,,,error row but skip,TRUE

--- a/tests/mitol/google_sheets_refunds/test_api.py
+++ b/tests/mitol/google_sheets_refunds/test_api.py
@@ -148,13 +148,20 @@ def test_full_sheet_process(db, settings, mocker, pygsheets_fixtures, request_cs
     mock_get_plugin_manager.assert_called_once()
 
     result = handler.process_sheet()
-    expected_processed_rows = {4, 5, 7, 9, 10}
+    expected_processed_rows = {5, 10}
     expected_failed_rows = {6}
+    expected_oos_rows = {7}
     assert ResultType.PROCESSED.value in result
     assert (
         set(result[ResultType.PROCESSED.value]) == expected_processed_rows
     ), "Rows %s as defined in refund_requests.csv should be processed" % str(
         expected_processed_rows
+    )
+    assert ResultType.OUT_OF_SYNC.value in result
+    assert (
+        set(result[ResultType.OUT_OF_SYNC.value]) == expected_oos_rows
+    ), "Rows %s as defined in refund_requests.csv should be out of sync" % str(
+        expected_oos_rows
     )
     assert ResultType.FAILED.value in result
     assert (

--- a/tests/mitol/google_sheets_refunds/test_api.py
+++ b/tests/mitol/google_sheets_refunds/test_api.py
@@ -148,7 +148,7 @@ def test_full_sheet_process(db, settings, mocker, pygsheets_fixtures, request_cs
     mock_get_plugin_manager.assert_called_once()
 
     result = handler.process_sheet()
-    expected_processed_rows = {4, 5, 7}
+    expected_processed_rows = {4, 5, 7, 9, 10}
     expected_failed_rows = {6}
     assert ResultType.PROCESSED.value in result
     assert (

--- a/tests/mitol/google_sheets_refunds/test_api.py
+++ b/tests/mitol/google_sheets_refunds/test_api.py
@@ -148,7 +148,7 @@ def test_full_sheet_process(db, settings, mocker, pygsheets_fixtures, request_cs
     mock_get_plugin_manager.assert_called_once()
 
     result = handler.process_sheet()
-    expected_processed_rows = {5, 10}
+    expected_processed_rows = {5, 10, 11}
     expected_failed_rows = {6}
     expected_oos_rows = {7}
     assert ResultType.PROCESSED.value in result


### PR DESCRIPTION
Original issue is https://github.com/mitodl/mitxonline/issues/1032

This code should skip over rows that have the Ignore flag set to TRUE (or whatever you've set the `GOOGLE_API_TRUE_VAL` to). This is accomplished by overloading the `filter_ignored_rows` function, so these rows are filtered from the sheet data entirely; they won't appear in any counts for ignored or failed rows. 

I also amended the test spreadsheet to capture a couple of other test cases - specifically, a row that hasn't been processed, one that had an existing error, and one that should be ignored.