### PR TITLE
Handle hubspot contacts with multiple emails

### DIFF
--- a/src/mitol/hubspot_api/api.py
+++ b/src/mitol/hubspot_api/api.py
@@ -262,7 +262,7 @@ def handle_create_api_error(
                     object_type=hubspot_type,
                 )
     # This was some other kind of error so raise it
-    raise
+    raise error
 
 
 def upsert_object_request(

--- a/src/mitol/hubspot_api/api.py
+++ b/src/mitol/hubspot_api/api.py
@@ -8,6 +8,7 @@ import logging
 import re
 from enum import Enum
 from typing import Dict, Iterable, List
+from urllib.parse import quote
 
 import requests
 from django.conf import settings
@@ -108,7 +109,7 @@ def delete_secondary_email(email: str, hubspot_id: str):
     """
     headers = {"Authorization": f"Bearer {settings.MITOL_HUBSPOT_API_PRIVATE_TOKEN}"}
     response = requests.delete(
-        f"https://api.hubapi.com/contacts/v1/secondary-email/{hubspot_id}/email/{email}?",
+        f"https://api.hubapi.com/contacts/v1/secondary-email/{hubspot_id}/email/{quote(email)}?",
         headers=headers,
     )
     response.raise_for_status()
@@ -168,6 +169,102 @@ def format_app_id(object_id: int) -> str:
     return "{}-{}".format(settings.MITOL_HUBSPOT_API_ID_PREFIX, object_id)
 
 
+def handle_secondary_email_error(content_type: str, hubspot_id: str, email: str) -> str:
+    """
+    Check if the Hubspot contact has multiple emails, and if so, remove secondary email
+
+     Args:
+        content_type(ContentType): The object content type
+        hubspot_type(str): The hubspot_api type (deals, contacts, etc)
+        hubspot_id(int): The hubspot id of the contact
+        email(str): The email of the user to add to Hubspot
+
+    Returns:
+        str: The primary email of the existing hubspot contact, if it exists
+
+    """
+    contact = find_contact(email)
+    other_hso = HubspotObject.objects.filter(
+        content_type=content_type, hubspot_id=hubspot_id
+    ).first()
+    if contact and other_hso:
+        if contact.properties["email"] == email:
+            # Delete the HubspotObject it will be synced again next time
+            other_hso.delete()
+            # Delete the secondary email for the other user
+            delete_secondary_email(other_hso.content_object.email, contact.id)
+        else:
+            # Delete the secondary email for this user
+            delete_secondary_email(email, contact.id)
+        return contact.properties["email"]
+    return None
+
+
+def handle_create_api_error(
+    error: ApiException,
+    content_type: str,
+    hubspot_type: str,
+    object_id: int = None,
+    body: SimplePublicObjectInput = None,
+    ignore_conflict=False,
+) -> SimplePublicObject:
+    """
+    Handle cases where an object already exists but hubspot_id is not in db
+
+     Args:
+        error(ApiException): The Hubspot API exception
+        content_type(ContentType): The object content type
+        hubspot_type(str): The hubspot_api type (deals, contacts, etc)
+        object_id(int): The database id of the object
+        body (SimplePublicObjectInput): The properties of the object to set in Hubspot
+        ignore_conflict(bool): If true, a conflict error on create will be retried as an update
+
+    Returns:
+        SimplePublicObject: The Hubspot object returned from the API - if an update is doable and succeeds
+
+    """
+    if error.status in (400, 409):
+        details = json.loads(error.body)
+        message = details.get("message", "")
+        hubspot_id_matches = [
+            match
+            for match in list(sum(re.findall(HUBSPOT_EXISTING_ID, message), ()))
+            if match
+        ]
+        retry_update = False
+        retry_create = False
+        if hubspot_id_matches:
+            hubspot_id = hubspot_id_matches[0]
+            if hubspot_type == HubspotObjectType.CONTACTS.value:
+                user_email = body.properties["email"]
+                secondary_email = handle_secondary_email_error(
+                    content_type, hubspot_id, user_email
+                )
+                if secondary_email == user_email:
+                    # Retry contact update w/this email
+                    retry_update = True
+                elif secondary_email:
+                    # Retry contact creation w/this email
+                    retry_create = True
+            elif object_id and not ignore_conflict:
+                retry_update = True
+            elif ignore_conflict:
+                return SimplePublicObject(id=hubspot_id)
+            if retry_update:
+                return HubspotApi().crm.objects.basic_api.update(
+                    simple_public_object_input=body,
+                    object_id=hubspot_id,
+                    object_type=hubspot_type,
+                )
+            elif retry_create:
+                return HubspotApi().crm.objects.basic_api.create(
+                    simple_public_object_input=body,
+                    object_type=hubspot_type,
+                )
+    # This was some other kind of error so raise it
+    raise
+
+
 def upsert_object_request(
     content_type: ContentType,
     hubspot_type: str,
@@ -201,57 +298,16 @@ def upsert_object_request(
             result = api.create(
                 simple_public_object_input=body, object_type=hubspot_type
             )
-        except ApiException as err:  # pylint:disable=broad-except
-            # Handle cases where an object already exists but hubspot_id is not in db (redo as a PATCH)
-            if err.status in (400, 409):
-                details = json.loads(err.body)
-                message = details.get("message", "")
-                hubspot_id_matches = [
-                    match
-                    for match in list(sum(re.findall(HUBSPOT_EXISTING_ID, message), ()))
-                    if match
-                ]
-                if hubspot_id_matches:
-                    hubspot_id = hubspot_id_matches[0]
-                    if hubspot_type == HubspotObjectType.CONTACTS.value:
-                        # Check if the Hubspot contact has multiple emails, and if so, remove secondary email
-                        contact = find_contact(body.properties["email"])
-                        other_hso = HubspotObject.objects.filter(
-                            content_type=content_type, hubspot_id=hubspot_id
-                        ).first()
-                        if other_hso:
-                            if contact.properties["email"] == body.properties["email"]:
-                                # Delete the HubspotObject matched on secondary email, it will be synced again next time
-                                other_hso.delete()
-                                # Delete the secondary email for the other user
-                                delete_secondary_email(
-                                    other_hso.content_object.email, contact.id
-                                )
-                            else:
-                                # Delete the secondary email for this user
-                                delete_secondary_email(
-                                    body.properties["email"], contact.id
-                                )
-                            # Try again
-                            return upsert_object_request(
-                                content_type,
-                                hubspot_type,
-                                object_id=object_id,
-                                body=body,
-                            )
-                    if object_id and not ignore_conflict:
-                        HubspotObject.objects.update_or_create(
-                            object_id=object_id,
-                            content_type=content_type,
-                            hubspot_id=hubspot_id,
-                        )
-                        return upsert_object_request(
-                            content_type, hubspot_type, object_id=object_id, body=body
-                        )
-                    elif ignore_conflict:
-                        return SimplePublicObject(id=hubspot_id)
-            raise
-    if object_id and not hubspot_id:
+        except ApiException as err:
+            result = handle_create_api_error(
+                err,
+                content_type,
+                hubspot_type,
+                object_id=object_id,
+                body=body,
+                ignore_conflict=ignore_conflict,
+            )
+    if object_id and result and not hubspot_id:
         HubspotObject.objects.update_or_create(
             object_id=object_id, content_type=content_type, hubspot_id=result.id
         )

--- a/src/mitol/hubspot_api/changelog.d/20230306_083847_mrbertrand_alt_emails.md
+++ b/src/mitol/hubspot_api/changelog.d/20230306_083847_mrbertrand_alt_emails.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- Handle hubspot contacts with multiple emails
+
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/tests/mitol/hubspot_api/test_api.py
+++ b/tests/mitol/hubspot_api/test_api.py
@@ -349,6 +349,7 @@ def test_upsert_object_contact_dupe_email(mocker, mock_hubspot_api, is_primary_e
         ),
     )
     mock_create = mock_hubspot_api.return_value.crm.objects.basic_api.create
+    mock_update = mock_hubspot_api.return_value.crm.objects.basic_api.update
     mock_exc = ApiException(
         http_resp=mocker.Mock(
             data=json.dumps(
@@ -367,6 +368,9 @@ def test_upsert_object_contact_dupe_email(mocker, mock_hubspot_api, is_primary_e
             mock_exc,
             SimplePublicObject(id=new_hubspot_id, properties={"email": new_user.email}),
         ]
+    )
+    mock_update.return_value = SimplePublicObject(
+        id=dupe_hubspot_id if is_primary_email else new_hubspot_id
     )
     mock_secondary = mocker.patch("mitol.hubspot_api.api.delete_secondary_email")
     body = SimplePublicObjectInput(properties={"email": new_user.email})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes https://github.com/mitodl/mitxonline/issues/1378

#### What's this PR do?
If a hubspot contact has multiple emails (primary, plus 1+ secondary), and those emails match multiple app `Users`, then the secondary email should be deleted.

#### How should this be manually tested?
To try this out in mitxonline, mitxpro, or bootcamps (examples below for mitxonline):
- Run `pants package ::` 
- Copy `dist/mitol-django-hubspot-api-2023.1.17.tar.gz` to the mitxonline repo directory
- In the app's `requirements.txt` file, replace `mitol-django-hubspot-api~=1.1.0` with `/app/mitol-django-hubspot-api-2023.1.17.tar.gz`:
  ```
  mitol-django-google-sheets-refunds==0.8.0
    # via -r requirements.in
  /app/mitol-django-hubspot-api-2023.1.17.tar.gz
    # via -r requirements.in
  mitol-django-mail==3.3.0
  ```
- In `Dockerfile`, move `COPY . /app` above `RUN pip install -r requirements.txt -r test_requirements.txt`:
  ```
  # Install project packages
  COPY . /app
  COPY requirements.txt /tmp/requirements.txt
  ```
- Run `docker-compose build --no-cache web celery`
- In your .env file, add  the same value for `MITOL_HUBSPOT_API_PRIVATE_TOKEN` as on RC, but use a unique value for `MITOL_HUBSPOT_API_ID_PREFIX`
- You will need access to the hubspot account for the app, let me know and I'll add you.
- Register a new user, for example `your_email+1@gmail.com`.  Go to the hubspot dashboard, find your user by email or name.  Add a secondary email for a new user that you plan on registering next, like `your_email+2@gmail.com`:
- 
<img width="950" alt="Screenshot 2023-01-26 at 4 01 32 PM" src="https://user-images.githubusercontent.com/187676/214949729-10365a12-8c84-4673-948d-57e561986433.png">


- Register as another user with that second email.  Wait a minute or so then refresh the hubspot detail page for the same contact as above.  The secondary email should be gone.  Search for that email and you should find a new contact that has it.
