### PR TITLE
Fixes payment_gateway changelog and missed formatting

### DIFF
--- a/src/mitol/payment_gateway/CHANGELOG.md
+++ b/src/mitol/payment_gateway/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.1]
+## [1.9.0] - 2023-02-10
+
+### Changed
+- Adds transaction search and lookup to the CyberSource payment gateway.
 
 ## [1.8.0] - 2023-01-17
 

--- a/src/mitol/payment_gateway/__init__.py
+++ b/src/mitol/payment_gateway/__init__.py
@@ -1,5 +1,5 @@
 """ mitol.openedx """
 default_app_config = "mitol.payment_gateway.apps.PaymentGatewayApp"
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"
 __distributionname__ = "mitol-django-payment-gateway"

--- a/src/mitol/payment_gateway/api.py
+++ b/src/mitol/payment_gateway/api.py
@@ -12,19 +12,27 @@ from decimal import Decimal
 from functools import wraps
 from typing import Dict, List
 
-from CyberSource import (CreateSearchRequest,
-                         Ptsv2paymentsClientReferenceInformation,
-                         Ptsv2paymentsidcapturesOrderInformationAmountDetails,
-                         Ptsv2paymentsidrefundsOrderInformation, RefundApi,
-                         RefundPaymentRequest, SearchTransactionsApi,
-                         TransactionDetailsApi)
+from CyberSource import (
+    CreateSearchRequest,
+    Ptsv2paymentsClientReferenceInformation,
+    Ptsv2paymentsidcapturesOrderInformationAmountDetails,
+    Ptsv2paymentsidrefundsOrderInformation,
+    RefundApi,
+    RefundPaymentRequest,
+    SearchTransactionsApi,
+    TransactionDetailsApi,
+)
 from django.conf import settings
 
 from mitol.common.utils.datetime import now_in_utc
-from mitol.payment_gateway.constants import (ISO_8601_FORMAT,
-                                             MITOL_PAYMENT_GATEWAY_CYBERSOURCE)
-from mitol.payment_gateway.exceptions import (InvalidTransactionException,
-                                              RefundDuplicateException)
+from mitol.payment_gateway.constants import (
+    ISO_8601_FORMAT,
+    MITOL_PAYMENT_GATEWAY_CYBERSOURCE,
+)
+from mitol.payment_gateway.exceptions import (
+    InvalidTransactionException,
+    RefundDuplicateException,
+)
 from mitol.payment_gateway.payment_utils import clean_request_data, strip_nones
 
 


### PR DESCRIPTION
This just adds the update to the changelog (forgot that the script doesn't do that part) and a `fmt` run that didn't get committed. No functional changes. 