### PR TITLE
Compare branch names as strings

### DIFF
--- a/build-support/bin/mitol/build_support/decorators.py
+++ b/build-support/bin/mitol/build_support/decorators.py
@@ -56,7 +56,7 @@ def app_option(func):
 def _no_require_main_callback(ctx: Context, param: str, value: bool) -> bool:
     if not value:
         project = ctx.find_object(Project)
-        if project.repo.active_branch != "main":
+        if project.repo.active_branch.name != "main":
             ctx.fail("Must be on main branch.")
 
     return value


### PR DESCRIPTION
Use `project.repo.active_branch.name` (`str`) instead of `project.repo.active_branch` (`git.refs.head.Head`) when comparing to "main"