### PR TITLE
Fix bug in hubspot error handling function

### DIFF
--- a/src/mitol/hubspot_api/api.py
+++ b/src/mitol/hubspot_api/api.py
@@ -246,10 +246,11 @@ def handle_create_api_error(
                 elif secondary_email:
                     # Retry contact creation w/this email
                     retry_create = True
-            elif object_id and not ignore_conflict:
-                retry_update = True
-            elif ignore_conflict:
-                return SimplePublicObject(id=hubspot_id)
+            if not retry_create and not retry_update:
+                if object_id and not ignore_conflict:
+                    retry_update = True
+                elif ignore_conflict:
+                    return SimplePublicObject(id=hubspot_id)
             if retry_update:
                 return HubspotApi().crm.objects.basic_api.update(
                     simple_public_object_input=body,

--- a/tests/mitol/hubspot_api/test_api.py
+++ b/tests/mitol/hubspot_api/test_api.py
@@ -257,13 +257,21 @@ def test_upsert_object_request_exists(mock_hubspot_api):
         [400, "Dupe error. {} already has that value."],
     ],
 )
+@pytest.mark.parametrize(
+    "hs_type",
+    [
+        api.HubspotObjectType.PRODUCTS.value,
+        api.HubspotObjectType.CONTACTS.value,
+    ],
+)
 @pytest.mark.django_db
 def test_upsert_object_request_missing_id(
-    mocker, mock_hubspot_api, content_type_obj, status, message
+    mocker, mock_hubspot_api, content_type_obj, status, message, hs_type
 ):
     """If an object exists in Hubspot but missing a HubspotObject in Django, retry upsert w/patch instead of post"""
     hubspot_id = "123456789"
     object_id = 123
+    new_email = "test@test.edu"
     mock_update = mock_hubspot_api.return_value.crm.objects.basic_api.update
     mock_update.return_value = SimplePublicObject(id=hubspot_id)
     mock_create = mock_hubspot_api.return_value.crm.objects.basic_api.create
@@ -278,10 +286,10 @@ def test_upsert_object_request_missing_id(
             status=status,
         )
     )
-    body = {"properties": {"foo": "bar"}}
+    body = SimplePublicObjectInput(properties={"email": new_email})
     api.upsert_object_request(
         content_type_obj,
-        api.HubspotObjectType.PRODUCTS.value,
+        hs_type,
         object_id=object_id,
         body=body,
     )


### PR DESCRIPTION
Closes https://github.com/mitodl/mitxonline/issues/1618

To test, follow the same instructions as PR https://github.com/mitodl/ol-django/pull/107, with some additional steps:

- Create a contact directly in hubspot with a certain email address.  
- In mitxonline, register a new user with that same email address.  Fill out the additional contact info after getting the verification email.  There should be no hubspot errors in the log.
- Go back to hubspot and refresh the contact details, you should see the populated fields from mitxonline like name, state, country, etc.