### PR TITLE
Set DEFAULT_AUTO_FIELD in app config

### DIFF
--- a/src/mitol/google_sheets_deferrals/apps.py
+++ b/src/mitol/google_sheets_deferrals/apps.py
@@ -10,6 +10,7 @@ class GoogleSheetsDeferralsApp(BaseApp):
     name = "mitol.google_sheets_deferrals"
     label = "google_sheets_deferrals"
     verbose_name = "Google Sheets Deferrals"
+    default_auto_field = "django.db.models.BigAutoField"
 
     required_settings = []
 

--- a/src/mitol/google_sheets_deferrals/changelog.d/20230524_090250_annagav_set_default_auto_field.md
+++ b/src/mitol/google_sheets_deferrals/changelog.d/20230524_090250_annagav_set_default_auto_field.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+- Set default_auto_field in app config
+
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->


### PR DESCRIPTION
Nothing should break

This fixes an error in mitxonline when running ./scripts/test/detect_missing_migrations.sh
```
Error: one or more migrations are missing
```