### PR TITLE
Adding refund and deferral request  model admin

### DIFF
--- a/src/mitol/google_sheets_deferrals/admin.py
+++ b/src/mitol/google_sheets_deferrals/admin.py
@@ -1,0 +1,14 @@
+"""Admin for DeferralRequest"""
+from django.contrib import admin
+
+from mitol.google_sheets_deferrals.models import DeferralRequest
+
+
+class DeferralRequestAdmin(admin.ModelAdmin):
+    """Admin for DeferralRequest"""
+
+    model = DeferralRequest
+    list_display = ("form_response_id", "date_completed", "raw_data")
+
+
+admin.site.register(DeferralRequest, DeferralRequestAdmin)

--- a/src/mitol/google_sheets_deferrals/changelog.d/20230609_113127_annagav_add_admin_sheets_requests.md
+++ b/src/mitol/google_sheets_deferrals/changelog.d/20230609_113127_annagav_add_admin_sheets_requests.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- Added DeferralRequestAdmin
+
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/mitol/google_sheets_refunds/admin.py
+++ b/src/mitol/google_sheets_refunds/admin.py
@@ -1,0 +1,14 @@
+"""Admin for RefundRequest"""
+from django.contrib import admin
+
+from mitol.google_sheets_refunds.models import RefundRequest
+
+
+class RefundRequestAdmin(admin.ModelAdmin):
+    """Admin for RefundRequest"""
+
+    model = RefundRequest
+    list_display = ("form_response_id", "date_completed", "raw_data")
+
+
+admin.site.register(RefundRequest, RefundRequestAdmin)

--- a/src/mitol/google_sheets_refunds/changelog.d/20230609_113137_annagav_add_admin_sheets_requests.md
+++ b/src/mitol/google_sheets_refunds/changelog.d/20230609_113137_annagav_add_admin_sheets_requests.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- Added RefundRequestAdmin
+
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->


### PR DESCRIPTION
# What are the relevant tickets?

 Helps https://github.com/mitodl/mitxonline/issues/1671

# Description (What does it do?)
Adding refund and deferral request  model admin

# Screenshots (if appropriate):
<img width="1121" alt="Screen Shot 2023-06-09 at 11 20 37 AM" src="https://github.com/mitodl/ol-django/assets/7574259/ec2c5b23-8da0-4e02-a51c-cb5385c003a8">


# How can this be tested?

1. ./pants package ::
2. cp dist/mitol-django-<name_of_package>-2023.1.17.tar.gz ../mitxonline
3. in requirements.txt add `/app/mitol-django-<name_of_package>-2023.1.17.tar.gz`
4. In Dockerfile, move `COPY . /app` above `RUN pip install -r requirements.txt -r test_requirements.txt`
5. docker-compose build

Go to mitxonline.odl.local:8013/admin and view the request model admin