### PR TITLE
Added pants init to the release actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,13 @@ jobs:
       with:
         python-version: 3.8
 
+    - name: Initialize Pants
+      uses: pantsbuild/actions/init-pants@7151afe1e66338457f7f65a894bc12a2d8f9cab7
+      with:
+        # cache0 makes it easy to bust the cache if needed
+        gha-cache-key: cache-${{ env.CACHE_BUST_ITER }}-py${{ matrix.python_version }}
+        named-caches-hash: ${{ hashFiles('build-support/lockfiles/*.lockfile') }}
+
     # extract the app name out of the tag's ref value
     - id: get-app-name
       uses: actions/github-script@v6


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
N/A

# Description (What does it do?)
<!--- Describe your changes in detail -->
This adds the pants initialization to the release part of our workflow, you can see this causing a failure here: https://github.com/mitodl/ol-django/actions/runs/5391166732/jobs/9787685668

# How can this be tested?
No way to test this because it can only be exercised when we do a release.