### PR TITLE
Update version month format

### DIFF
--- a/src/mitol/olposthog/__init__.py
+++ b/src/mitol/olposthog/__init__.py
@@ -1,5 +1,5 @@
 """ mitol.olposthog """
 default_app_config = "mitol.olposthog.apps.OlPosthog"
 
-__version__ = "2024.04.12.1"
+__version__ = "2024.4.12.1"
 __distributionname__ = "mitol-django-OlPosthog"

--- a/src/mitol/olposthog/changelog.d/20240424_160908_collin_preston_update_olposthog_version.rst
+++ b/src/mitol/olposthog/changelog.d/20240424_160908_collin_preston_update_olposthog_version.rst
@@ -1,0 +1,34 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Removed
+.. -------
+..
+.. - A bullet item for the Removed category.
+..
+.. Added
+.. -----
+..
+.. - A bullet item for the Added category.
+..
+Changed
+-------
+
+- Version date from using 04 to 4.
+..
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. -----
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..

--- a/src/mitol/olposthog/pyproject.toml
+++ b/src/mitol/olposthog/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "mitol-olposthog"
-version = "2024.04.16"
+version = "2024.4.16"
 
 [tool.bumpver]
-current_version = "2024.04.16"
+current_version = "2024.4.16"
 version_pattern = "YYYY.MM.DD[.INC0]"
 
 [tool.bumpver.file_patterns]


### PR DESCRIPTION
I guess, according to https://github.com/mbarkhau/bumpver?tab=readme-ov-file#pattern-examples, MM in the version means I should use `4` instead of `04`.