### PR TITLE
Add an option to process only last rows

### DIFF
--- a/src/mitol/google_sheets/README.md
+++ b/src/mitol/google_sheets/README.md
@@ -39,6 +39,7 @@ MITOL_GOOGLE_SHEETS_DRIVE_CLIENT_SECRET=<Client secret from step 1>
 MITOL_GOOGLE_SHEETS_DRIVE_API_PROJECT_ID=<Project ID from step 2>
 MITOL_GOOGLE_SHEETS_PROCESSOR_APP_NAME=<Name of the app processing the request>
 MITOL_GOOGLE_SHEETS_ENROLLMENT_CHANGE_SHEET_ID=<Change of enrollment request sheet ID from step 3>
+MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM=<Optional: the number of rows to process from the bottom>
 ```
 
 

--- a/src/mitol/google_sheets/changelog.d/20240624_153353_annagav_process_only_last_rows.md
+++ b/src/mitol/google_sheets/changelog.d/20240624_153353_annagav_process_only_last_rows.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- Added MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM to control how many rows 
+from the spreadsheet are being processed.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/mitol/google_sheets/settings/google_sheets.py
+++ b/src/mitol/google_sheets/settings/google_sheets.py
@@ -47,6 +47,13 @@ MITOL_GOOGLE_SHEETS_ENROLLMENT_CHANGE_SHEET_ID = get_string(
         "ID of the Google Sheet that contains the enrollment change request worksheets (refunds, transfers, etc)"
     ),
 )
+MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM = get_string(
+    name="MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM",
+    default=30,
+    description=(
+        "Process only the last N rows of data. If set to 0 then process all rows. "
+    ),
+)
 MITOL_GOOGLE_SHEETS_DATE_FORMAT = get_string(
     name="MITOL_GOOGLE_SHEETS_DATE_FORMAT",
     default="%m/%d/%Y",

--- a/src/mitol/google_sheets/sheet_handler_api.py
+++ b/src/mitol/google_sheets/sheet_handler_api.py
@@ -146,9 +146,21 @@ class SheetHandler:
         processed_row_results = grouped_row_results.get(ResultType.PROCESSED, [])
         if processed_row_results:
             self.update_completed_rows(processed_row_results)
+            log.warning(
+                "Successfully processed rows in %s (%s): %s",
+                self.sheet_metadata.sheet_name,
+                self.sheet_metadata.worksheet_name,
+                [row_result.row_index for row_result in processed_row_results],
+            )
         failed_row_results = grouped_row_results.get(ResultType.FAILED, [])
         if failed_row_results:
             self.update_row_errors(failed_row_results)
+            log.warning(
+                "Processed rows with errors in %s (%s): %s",
+                self.sheet_metadata.sheet_name,
+                self.sheet_metadata.worksheet_name,
+                [row_result.row_index for row_result in failed_row_results],
+            )
         out_of_sync_row_results = grouped_row_results.get(ResultType.OUT_OF_SYNC, [])
         if out_of_sync_row_results:
             log.warning(
@@ -257,10 +269,9 @@ class SheetHandler:
         for row_index, row_data in valid_enumerated_rows:
             row_result = None
             try:
-                log.warning("Process row %s, %s", row_index, row_data)
                 row_result = self.process_row(row_index, row_data)
             except Exception as exc:
-                log.exception("Error processing row from google sheets")
+                log.exception("Error processing row %s from google sheets", row_index)
                 row_result = RowResult(
                     row_index=row_index,
                     row_db_record=None,
@@ -316,7 +327,6 @@ class GoogleSheetsChangeRequestHandler(SheetHandler):
         # Only yield rows in the spreadsheet that come after the legacy rows
         # (i.e.: the rows of data that were manually entered before we started automating this process)
         row_count = len(self.worksheet.get_all_values(include_tailing_empty_rows=False))
-        logging.warning("Worksheet has %d rows", row_count)
         first_row_to_process = self.start_row
         if int(settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM) > 0:
             # allow to choose to process only last few rows
@@ -326,7 +336,7 @@ class GoogleSheetsChangeRequestHandler(SheetHandler):
             first_row_to_process = (
                 new_first_row if new_first_row > self.start_row else self.start_row
             )
-        logging.warning("Calculated first row: %s", first_row_to_process)
+        logging.warning("Going to process the sheet starting with row %s", first_row_to_process)
         return enumerate(
             get_data_rows_after_start(
                 self.worksheet,

--- a/src/mitol/google_sheets/sheet_handler_api.py
+++ b/src/mitol/google_sheets/sheet_handler_api.py
@@ -332,7 +332,7 @@ class GoogleSheetsChangeRequestHandler(SheetHandler):
             # allow to choose to process only last few rows
             new_first_row = row_count - int(
                 settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM
-            )
+            ) + 1
             first_row_to_process = (
                 new_first_row if new_first_row > self.start_row else self.start_row
             )

--- a/src/mitol/google_sheets/sheet_handler_api.py
+++ b/src/mitol/google_sheets/sheet_handler_api.py
@@ -330,13 +330,15 @@ class GoogleSheetsChangeRequestHandler(SheetHandler):
         first_row_to_process = self.start_row
         if int(settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM) > 0:
             # allow to choose to process only last few rows
-            new_first_row = (
-                row_count - int(settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM)
+            new_first_row = row_count - int(
+                settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM
             )
             first_row_to_process = (
                 new_first_row if new_first_row > self.start_row else self.start_row
             )
-        logging.warning("Going to process the sheet starting with row %s", first_row_to_process)
+        logging.warning(
+            "Going to process the sheet starting with row %s", first_row_to_process
+        )
         return enumerate(
             get_data_rows_after_start(
                 self.worksheet,

--- a/src/mitol/google_sheets/sheet_handler_api.py
+++ b/src/mitol/google_sheets/sheet_handler_api.py
@@ -330,9 +330,11 @@ class GoogleSheetsChangeRequestHandler(SheetHandler):
         first_row_to_process = self.start_row
         if int(settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM) > 0:
             # allow to choose to process only last few rows
-            new_first_row = row_count - int(
-                settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM
-            ) + 1
+            new_first_row = (
+                row_count
+                - int(settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM)
+                + 1
+            )
             first_row_to_process = (
                 new_first_row if new_first_row > self.start_row else self.start_row
             )

--- a/src/mitol/google_sheets/sheet_handler_api.py
+++ b/src/mitol/google_sheets/sheet_handler_api.py
@@ -98,7 +98,7 @@ class SheetHandler:
         # By default, the first worksheet of the spreadsheet should be used
         return self.spreadsheet.sheet1
 
-    def get_enumerated_rows(self):
+    def get_enumerated_rows(self, from_row=None):
         """
         Yields enumerated data rows of a spreadsheet (excluding header row(s))
 
@@ -108,7 +108,7 @@ class SheetHandler:
         """
         yield from enumerate(
             get_data_rows(self.worksheet, include_trailing_empty=False),
-            start=GOOGLE_SHEET_FIRST_ROW + 1,
+            start=from_row if from_row is not None else (GOOGLE_SHEET_FIRST_ROW + 1),
         )
 
     def update_completed_rows(self, success_row_results):

--- a/src/mitol/google_sheets/sheet_handler_api.py
+++ b/src/mitol/google_sheets/sheet_handler_api.py
@@ -100,7 +100,8 @@ class SheetHandler:
 
     def get_enumerated_rows(self, from_row=None):
         """
-        Yields enumerated data rows of a spreadsheet (excluding header row(s))
+        Yields enumerated data rows of a spreadsheet (excluding header row(s)) or
+        from a specified row.
 
         Yields:
             Tuple[int, List[str]]: Row index (according to the Google Sheet, NOT zero-indexed) paired with the list

--- a/src/mitol/google_sheets/utils.py
+++ b/src/mitol/google_sheets/utils.py
@@ -206,8 +206,12 @@ def get_data_rows_after_start(
             first_row_to_process = start_row
         else:
             # allow to choose to process only last few rows
-            new_first_row = end_row - settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM
-            first_row_to_process = new_first_row if new_first_row > start_row else start_row
+            new_first_row = (
+                end_row - settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM
+            )
+            first_row_to_process = (
+                new_first_row if new_first_row > start_row else start_row
+            )
         values = worksheet.get_values(
             start=(first_row_to_process, start_col),
             end=(end_row, end_col),

--- a/src/mitol/google_sheets/utils.py
+++ b/src/mitol/google_sheets/utils.py
@@ -184,6 +184,8 @@ def get_data_rows_after_start(
     """
     Yields the data rows of a spreadsheet starting with a given row and spanning a given column range
     until empty rows are encountered.
+    If MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM == 0 it will process all rows. Otherwise, it will process
+    only the last few rows.
 
     Args:
         worksheet (pygsheets.worksheet.Worksheet): Worksheet object
@@ -200,8 +202,14 @@ def get_data_rows_after_start(
     values = []
     while request_count == 0 or (values and len(values) == page_size):
         end_row = start_row + page_size - 1
+        if settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM == 0:
+            first_row_to_process = start_row
+        else:
+            # allow to choose to process only last few rows
+            new_first_row = end_row - settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM
+            first_row_to_process = new_first_row if new_first_row > start_row else start_row
         values = worksheet.get_values(
-            start=(start_row, start_col),
+            start=(first_row_to_process, start_col),
             end=(end_row, end_col),
             include_tailing_empty=True,
             include_tailing_empty_rows=False,

--- a/src/mitol/google_sheets/utils.py
+++ b/src/mitol/google_sheets/utils.py
@@ -1,6 +1,7 @@
 """Sheets app util functions"""
 import datetime
 import email.utils
+import logging
 from collections import namedtuple
 from enum import Enum
 from urllib.parse import quote_plus, urljoin
@@ -202,18 +203,8 @@ def get_data_rows_after_start(
     values = []
     while request_count == 0 or (values and len(values) == page_size):
         end_row = start_row + page_size - 1
-        if settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM == 0:
-            first_row_to_process = start_row
-        else:
-            # allow to choose to process only last few rows
-            new_first_row = (
-                end_row - settings.MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM
-            )
-            first_row_to_process = (
-                new_first_row if new_first_row > start_row else start_row
-            )
         values = worksheet.get_values(
-            start=(first_row_to_process, start_col),
+            start=(start_row, start_col),
             end=(end_row, end_col),
             include_tailing_empty=True,
             include_tailing_empty_rows=False,

--- a/src/mitol/google_sheets/utils.py
+++ b/src/mitol/google_sheets/utils.py
@@ -1,7 +1,6 @@
 """Sheets app util functions"""
 import datetime
 import email.utils
-import logging
 from collections import namedtuple
 from enum import Enum
 from urllib.parse import quote_plus, urljoin


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/4550 and https://github.com/mitodl/hq/issues/4503
### Description (What does it do?)
This PR attempts to reduce the time the task is running and to prevent unnecessary reprocessing of the whole sheet, since it is only getting longer. 
Add a log info message to state which rows got processed.

### How can this be tested?
You would need to set up google sheets to run locally. Follow the instructions [here.](https://github.com/mitodl/ol-django/blob/85bea3ec5da01180ef943deb89b14d1463eb7c21/src/mitol/google_sheets/README.md#developer-setup)

Here is the list of vars that you need set in your .env file in your local mitxonline:
```
MITX_ONLINE_BASE_URL=<your_ngrok_url>
MITOL_GOOGLE_SHEETS_DRIVE_CLIENT_ID=<your_client_id>
MITOL_GOOGLE_SHEETS_DRIVE_CLIENT_SECRET=<your_secret>
MITOL_GOOGLE_SHEETS_DRIVE_API_PROJECT_ID=<your_google_project_id>
MITOL_GOOGLE_SHEETS_PROCESSOR_APP_NAME=mitxonline-refunds-local
MITOL_GOOGLE_SHEETS_ENROLLMENT_CHANGE_SHEET_ID=<sheet_id>
MITOL_GOOGLE_SHEETS_REFUNDS_REQUEST_WORKSHEET_ID=0
MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM=30
GOOGLE_DOMAIN_VERIFICATION_TAG_VALUE=<unique_code>
CSRF_TRUSTED_ORIGINS=<your_ngrok_url_without_https>,
```


To test the changes of google sheets in your mitxonline instance you would need to :
1. In ol-django run `pants package ::`
2. Then copy the file to your mitxonline repo: `cp dist/mitol-django-google-sheets-2023.12.19.1.tar.gz ../mitxonline`
3. In mitxonline in pyproject.toml
```
-mitol-django-google-sheets = "2023.12.19.1"
+mitol-django-google-sheets = {path = "mitol-django-google-sheets-2023.12.19.1.tar.gz", develop = true}
```
4. In Dockerfile move `COPY . /app` before `RUN poetry install`
5. Run `docker-compose build`


When your task is running successfully you should see logs about the rows that are being processed,  "Going to process the sheet starting with row 6" 
"Ignored rows in Enrollment Change Request sheet (Refunds): [6, 7, 8]"
"Processed rows with errors in Enrollment Change Request sheet (Refunds): [6, 7, 8]"

Try setting `MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM=2` in your .env file, then clear all the errors from the sheet and wait the task to run again. It should process only the last 2 rows. By default it is set to 30 rows. If the number of filled out rows is less the `MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM` it will process all rows.