### PR TITLE
Add GH actions workflow for Renovate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,11 @@ jobs:
     - name: Install dependencies
       run: rye sync
 
-      # - name: Lints
-      #   run: 'pants lint ::'
-
-      # - name: Typecheck
-      #   run: 'pants typecheck ::'
-
     - name: Tests
       run: rye test
 
     - name: Changelog
+      if: ${{ !contains(github.event.head_commit.author, 'renovate') }}
       run: rye run build changelog check
 
       # - name: Upload coverage to CodeCov

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,27 @@
+---
+name: Renovate
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: '0 0 * * *'
+permissions:
+  pull-requests: write
+  contents: write
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4.1.6
+
+    - name: Apt install
+      run: sudo apt-get update && sudo apt-get install -y libxmlsec1-dev
+
+    - uses: eifinger/setup-rye@v4
+      id: setup-rye
+
+    - name: Self-hosted Renovate
+      uses: renovatebot/github-action@v40.2.4
+      with:
+        configurationFile: renovate-config.json
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,0 +1,5 @@
+{
+  "allowedPostUpgradeCommands": [
+    "rye .*"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>mitodl/.github:renovate-config"
-  ]
+  ],
+  "postUpgradeTasks": {
+    "commands": ["rye sync"],
+    "fileFilters": ["requirements*.lock"],
+    "executionMode": "update"
+  }
 }


### PR DESCRIPTION
### What are the relevant tickets?
Closes #155 

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds a GH Actions workflow definition for running Renovate directly rather than using the managed app.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Execute the new workflow definition and verify that Renovate updates outdated dependencies and keeps the Rye lockfiles updated.
