### PR TITLE
Payment Gateway: Add tax support

### DIFF
--- a/src/payment_gateway/changelog.d/20241107_212223_jkachel_add_tax.md
+++ b/src/payment_gateway/changelog.d/20241107_212223_jkachel_add_tax.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- Adds support for tax collection.
+- Bumps CyberSource REST Client package to at least 0.0.54.
+- Adds a helper for quantizing decimals for currency amounts.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/payment_gateway/mitol/payment_gateway/api.py
+++ b/src/payment_gateway/mitol/payment_gateway/api.py
@@ -34,7 +34,7 @@ from mitol.payment_gateway.exceptions import (
     InvalidTransactionException,
     RefundDuplicateException,
 )
-from mitol.payment_gateway.payment_utils import clean_request_data, strip_nones
+from mitol.payment_gateway.payment_utils import clean_request_data, strip_nones, quantize_decimal
 
 
 @dataclass
@@ -461,8 +461,8 @@ class CyberSourcePaymentGateway(
 
         payload = {
             "access_key": settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY,
-            "amount": str(total + tax_total),
-            "tax_amount": str(tax_total),
+            "amount": str(quantize_decimal((total + tax_total))),
+            "tax_amount": str(quantize_decimal((tax_total))),
             "consumer_id": consumer_id,
             "currency": "USD",
             "locale": "en-us",

--- a/src/payment_gateway/mitol/payment_gateway/api.py
+++ b/src/payment_gateway/mitol/payment_gateway/api.py
@@ -362,6 +362,10 @@ class CyberSourcePaymentGateway(
     def _generate_line_items(self, cart):
         """
         Generates CyberSource-formatted line items based on what's in the cart.
+
+        The unit price being stored should be the unit price after any discounts
+        have been applied. The tax amount should be the _total_ for the line.
+
         Args:
             cart:   List of CartItems
 
@@ -370,9 +374,11 @@ class CyberSourcePaymentGateway(
         """  # noqa: D401
         lines = {}
         cart_total = 0
+        tax_total = 0
 
         for i, line in enumerate(cart):
             cart_total += line.quantity * line.unitprice
+            tax_total += line.taxable
 
             lines[f"item_{i}_code"] = str(line.code)
             lines[f"item_{i}_name"] = str(line.name)[:254]
@@ -381,7 +387,7 @@ class CyberSourcePaymentGateway(
             lines[f"item_{i}_tax_amount"] = str(line.taxable)
             lines[f"item_{i}_unit_price"] = str(line.unitprice)
 
-        return (lines, cart_total)
+        return (lines, cart_total, tax_total)
 
     def _generate_cybersource_sa_signature(self, payload):
         """
@@ -438,7 +444,7 @@ class CyberSourcePaymentGateway(
         stored anywhere.
         """  # noqa: D401
 
-        (line_items, total) = self._generate_line_items(order.items)
+        (line_items, total, tax_total) = self._generate_line_items(order.items)
 
         formatted_merchant_fields = {}
 
@@ -455,7 +461,8 @@ class CyberSourcePaymentGateway(
 
         payload = {
             "access_key": settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY,
-            "amount": str(total),
+            "amount": str(total + tax_total),
+            "tax_amount": str(tax_total),
             "consumer_id": consumer_id,
             "currency": "USD",
             "locale": "en-us",

--- a/src/payment_gateway/mitol/payment_gateway/payment_utils.py
+++ b/src/payment_gateway/mitol/payment_gateway/payment_utils.py
@@ -1,5 +1,7 @@
 """Utilities for the Payment Gateway"""
 
+from decimal import Decimal
+
 
 # To delete None values in Input Request Json body
 def clean_request_data(request_data):
@@ -21,3 +23,8 @@ def strip_nones(datasource):
             retval[key] = datasource[key]
 
     return retval
+
+
+def quantize_decimal(value, precision=2):
+    """Quantize a decimal value to the specified precision"""
+    return Decimal(value).quantize(Decimal("0.{}".format("0" * precision)))

--- a/src/payment_gateway/pyproject.toml
+++ b/src/payment_gateway/pyproject.toml
@@ -3,7 +3,7 @@ name = "mitol-django-payment-gateway"
 version = "2023.12.19"
 description = "Django application to handle payment processing"
 dependencies = [
-"cybersource-rest-client-python>=0.0.36",
+"cybersource-rest-client-python>=0.0.59",
 "django-stubs>=1.13.1",
 "django>=3.0",
 "mitol-django-common"

--- a/tests/mitol/payment_gateway/api/test_cybersource.py
+++ b/tests/mitol/payment_gateway/api/test_cybersource.py
@@ -5,6 +5,7 @@ import random
 from collections import namedtuple
 from dataclasses import dataclass
 from datetime import datetime
+from decimal import Decimal
 from typing import Dict
 
 import pytest
@@ -98,8 +99,8 @@ def generate_test_cybersource_payload(order, cartitems, transaction_uuid):
 
     test_payload = {
         "access_key": settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY,
-        "amount": str(test_total + tax_total),
-        "tax_amount": str(tax_total),
+        "amount": str(Decimal(test_total + tax_total).quantize(Decimal("0.01"))),
+        "tax_amount": str(Decimal(tax_total).quantize(Decimal("0.01"))),
         "consumer_id": consumer_id,
         "currency": "USD",
         "locale": "en-us",

--- a/tests/mitol/payment_gateway/api/test_cybersource.py
+++ b/tests/mitol/payment_gateway/api/test_cybersource.py
@@ -81,10 +81,11 @@ def generate_test_cybersource_payload(order, cartitems, transaction_uuid):
     cancel_url = "https://duckduckgo.com"
 
     test_line_items = {}
-    test_total = 0
+    test_total = tax_total = 0
 
     for idx, line in enumerate(cartitems):
         test_total += line.quantity * line.unitprice
+        tax_total += line.taxable
 
         test_line_items[f"item_{idx}_code"] = str(line.code)
         test_line_items[f"item_{idx}_name"] = str(line.name)[:254]
@@ -97,7 +98,8 @@ def generate_test_cybersource_payload(order, cartitems, transaction_uuid):
 
     test_payload = {
         "access_key": settings.MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY,
-        "amount": str(test_total),
+        "amount": str(test_total + tax_total),
+        "tax_amount": str(tax_total),
         "consumer_id": consumer_id,
         "currency": "USD",
         "locale": "en-us",
@@ -140,7 +142,8 @@ def test_invalid_payload_generation(order, cartitems):
     assert isinstance(checkout_data, TypeError)
 
 
-def test_cybersource_payload_generation(order, cartitems):
+@pytest.mark.parametrize(("with_tax"), [(True), (False),])
+def test_cybersource_payload_generation(order, cartitems, with_tax):
     """
     Starts a payment through the payment gateway, and then checks to make sure
     there's stuff in the payload that it generates. The transaction is not sent
@@ -150,6 +153,11 @@ def test_cybersource_payload_generation(order, cartitems):
     backoffice_post_url = "https://www.google.com"
     cancel_url = "https://duckduckgo.com"
     order.items = cartitems
+
+    # By default, the cart items will have tax.
+    if not with_tax:
+        for idx in range(len(order.items)):
+            order.items[idx].taxable = 0
 
     checkout_data = PaymentGateway.start_payment(
         MITOL_PAYMENT_GATEWAY_CYBERSOURCE,

--- a/tests/mitol/payment_gateway/utils/test_payment_utils.py
+++ b/tests/mitol/payment_gateway/utils/test_payment_utils.py
@@ -1,7 +1,9 @@
 """Tests for payment_gateway application utils"""  # noqa: INP001
 
+from decimal import Decimal
+
 import pytest
-from mitol.payment_gateway.payment_utils import clean_request_data, strip_nones
+from mitol.payment_gateway.payment_utils import clean_request_data, strip_nones, quantize_decimal
 
 
 @pytest.mark.parametrize(
@@ -44,3 +46,14 @@ def test_strip_nones():
     test_ds2 = strip_nones(ds2)
 
     assert test_ds2 == ds2
+
+
+def test_quantize_decimal():
+    """Tests quantize_decimal to make sure that the decimal is quantized to the correct precision"""
+
+    test_decimal = 1.23456789
+    test_precision = 2
+
+    quantized_decimal = quantize_decimal(test_decimal, test_precision)
+
+    assert quantized_decimal == Decimal("1.23")

--- a/tests/testapp/factories.py
+++ b/tests/testapp/factories.py
@@ -3,7 +3,8 @@
 import string
 
 import faker
-from factory import Factory, SubFactory, fuzzy
+from decimal import Decimal
+from factory import Factory, SubFactory, fuzzy, LazyAttribute
 from factory.django import DjangoModelFactory
 from mitol.common.factories import UserFactory
 from mitol.digitalcredentials.factories import (
@@ -46,8 +47,8 @@ class CartItemFactory(Factory):
     code = fuzzy.FuzzyText(length=6)
     quantity = fuzzy.FuzzyInteger(1, 5, 1)
     name = FAKE.sentence(nb_words=3)
-    taxable = 0
     unitprice = fuzzy.FuzzyDecimal(1, 300, precision=2)
+    taxable = LazyAttribute(lambda o: Decimal(o.unitprice * Decimal(FAKE.random_number(2) * .01)).quantize(Decimal('0.01')))
 
 
 class OrderFactory(Factory):

--- a/uv.lock
+++ b/uv.lock
@@ -1338,7 +1338,7 @@ requires-dist = [
 
 [[package]]
 name = "mitol-django-geoip"
-version = "2024.10.25"
+version = "2024.11.5"
 source = { editable = "src/geoip" }
 dependencies = [
     { name = "django" },
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cybersource-rest-client-python", specifier = ">=0.0.36" },
+    { name = "cybersource-rest-client-python", specifier = ">=0.0.59" },
     { name = "django", specifier = ">=3.0" },
     { name = "django-stubs", specifier = ">=1.13.1" },
     { name = "mitol-django-common", editable = "src/common" },


### PR DESCRIPTION
### What are the relevant tickets?

Part of https://github.com/mitodl/unified-ecommerce/pull/166

### Description (What does it do?)

The payment_gateway app does not support tax - you can add the tax to the line item but it doesn't total it, and that causes some errors with CyberSource. This adds that support.

This also adds a helper to ensure that the calculated values are quantized to 2 decimal places (using Decimal) - CyberSource will also throw an error if the values are more precise than they need to be.

### How can this be tested?

Automated tests should pass. You can build the package with `uv run build --package mitol-django-payment_gateway` and install it in an app that uses it (MITx Online) for testing too.
