### PR TITLE
Bump pluggy version - should now accept any version from 0.13.1 on

### DIFF
--- a/src/google_sheets_deferrals/changelog.d/20250131_170128_jkachel_update_pluggy_dependencies.md
+++ b/src/google_sheets_deferrals/changelog.d/20250131_170128_jkachel_update_pluggy_dependencies.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+### Changed
+
+- Updated pluggy dependency (from 0.13 to anything 0.13 up)
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/google_sheets_deferrals/pyproject.toml
+++ b/src/google_sheets_deferrals/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
 "django>=3.0",
 "mitol-django-common",
 "mitol-django-google-sheets",
-"pluggy>=0.13.1",
+"pluggy>0.13.1",
 ]
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/google_sheets_refunds/changelog.d/20250131_170125_jkachel_update_pluggy_dependencies.md
+++ b/src/google_sheets_refunds/changelog.d/20250131_170125_jkachel_update_pluggy_dependencies.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+### Changed
+
+- Updated pluggy dependency (from 0.13 to anything 0.13 up)
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/google_sheets_refunds/pyproject.toml
+++ b/src/google_sheets_refunds/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
 "django>=3.0",
 "mitol-django-common",
 "mitol-django-google-sheets",
-"pluggy>=0.13.1",
+"pluggy>0.13.1",
 ]
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/uv.lock
+++ b/uv.lock
@@ -1404,7 +1404,7 @@ requires-dist = [
     { name = "django-stubs", specifier = ">=1.13.1" },
     { name = "mitol-django-common", editable = "src/common" },
     { name = "mitol-django-google-sheets", editable = "src/google_sheets" },
-    { name = "pluggy", specifier = ">=0.13.1" },
+    { name = "pluggy", specifier = ">0.13.1" },
 ]
 
 [[package]]
@@ -1425,7 +1425,7 @@ requires-dist = [
     { name = "django-stubs", specifier = ">=1.13.1" },
     { name = "mitol-django-common", editable = "src/common" },
     { name = "mitol-django-google-sheets", editable = "src/google_sheets" },
-    { name = "pluggy", specifier = ">=0.13.1" },
+    { name = "pluggy", specifier = ">0.13.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What are the relevant tickets?

mitodl/hq#6042

### Description (What does it do?)

Unified Ecommerce uses a newer version of pluggy than 0.13.1, so this just updates the requirement so that I can install the refunds app. 

### How can this be tested?

Automated tests should work. There aren't any code changes; this is just a dependency version bump, and the relevant changelogs didn't note anything that would cause issues with these apps.

MITx Online uses this currently so potential testing route is building these apps and then installing them in a working MITx Online installation, then making sure it doesn't blow up.
