### PR TITLE
Wraps the CyberSource imports in a warnings filter

### DIFF
--- a/src/payment_gateway/changelog.d/20250227_142343_jkachel_wrap_cybersource_imports.md
+++ b/src/payment_gateway/changelog.d/20250227_142343_jkachel_wrap_cybersource_imports.md
@@ -1,0 +1,40 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+### Changed
+
+- Wrap the imports for CyberSource; they generate `SyntaxWarning`s, so this should quiet them down (and allow them to pass tests)
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/payment_gateway/mitol/payment_gateway/api.py
+++ b/src/payment_gateway/mitol/payment_gateway/api.py
@@ -7,21 +7,24 @@ import hashlib
 import hmac
 import json
 import uuid
+import warnings
 from base64 import b64encode
 from dataclasses import dataclass
 from decimal import Decimal
 from functools import wraps
 
-from CyberSource import (
-    CreateSearchRequest,
-    Ptsv2paymentsClientReferenceInformation,
-    Ptsv2paymentsidcapturesOrderInformationAmountDetails,
-    Ptsv2paymentsidrefundsOrderInformation,
-    RefundApi,
-    RefundPaymentRequest,
-    SearchTransactionsApi,
-    TransactionDetailsApi,
-)
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=SyntaxWarning)
+    from CyberSource import (
+        CreateSearchRequest,
+        Ptsv2paymentsClientReferenceInformation,
+        Ptsv2paymentsidcapturesOrderInformationAmountDetails,
+        Ptsv2paymentsidrefundsOrderInformation,
+        RefundApi,
+        RefundPaymentRequest,
+        SearchTransactionsApi,
+        TransactionDetailsApi,
+    )
 from django.conf import settings
 
 from mitol.common.utils.datetime import now_in_utc

--- a/uv.lock
+++ b/uv.lock
@@ -1268,7 +1268,7 @@ requires-dist = [
 
 [[package]]
 name = "mitol-django-google-sheets"
-version = "2025.2.4"
+version = "2025.2.27"
 source = { editable = "src/google_sheets" }
 dependencies = [
     { name = "django" },
@@ -1318,7 +1318,7 @@ requires-dist = [
 
 [[package]]
 name = "mitol-django-google-sheets-refunds"
-version = "2025.2.3"
+version = "2025.2.27"
 source = { editable = "src/google_sheets_refunds" }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
### What are the relevant tickets?

Related to https://github.com/mitodl/hq/issues/5951
Related to https://github.com/mitodl/mitxonline/pull/2551

### Description (What does it do?)

The CyberSource Python REST client library uses a couple of regexes that aren't in raw strings, and (starting with Python 3.12) doing that raises a SyntaxWarning. (This was deprecated in 3.6 but in between then and 3.12 it raised a DeprecationWarning, which is usually invisible.) Wrapping these in a `catch_warnings` context manager lets us filter out SyntaxWarning, so we can make it quiet. (pytest also sometimes regards these as _errors_, which keeps your tests from passing when using Python 3.12+, so this should fix that too.) It would be better for the upstream to be fixed but we can do this until that happens.

### How can this be tested?

Automated tests should pass. Running tests using Python 3.12 or 3.13 should work. You can do this with `uv run --python 3.13 pytest tests/payment_gateway/**/*.py` (or 3.12).

It would be best to build and pull the built version of this into MITx Online and see how that works there with a more recent (>=3.12) version of Python.

This otherwise has no functional changes - it just slightly changes the imports in one file.