### PR TITLE
Remove `uv sync` from renovate which runs it now

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>mitodl/.github:renovate-config"
-  ],
-  "postUpgradeTasks": {
-    "commands": ["uv sync"],
-    "fileFilters": ["uv*.lock"],
-    "executionMode": "update"
-  }
+  ]
 }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This removes the `uv sync` post upgrade command which a) isn't necessary because it appears Renovate runs this itself and b) is failing anyway because it's only available for self-hosted renovate instances.

This will allow renovate to update dependencies with less human intervention.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass