### PR TITLE
Added support for python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
         - "3.10"
         - "3.11"
         - "3.12"
+        - "3.13"
 
     # Service containers to run
     services:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
     args:
     - --baseline
     - .secrets.baseline
+    additional_dependencies: ["gibberish_detector"]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
   rev: 'v0.5.7'

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -99,6 +99,10 @@
       "min_level": 2
     },
     {
+      "path": "detect_secrets.filters.gibberish.should_exclude_secret",
+      "limit": 3.7
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
@@ -127,63 +131,6 @@
     }
   ],
   "results": {
-    ".github/workflows/ci.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/ci.yml",
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_verified": false,
-        "line_number": 20
-      }
-    ],
-    "conftest.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "conftest.py",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 123
-      }
-    ],
-    "docker-compose.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docker-compose.yml",
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_verified": false,
-        "line_number": 8
-      },
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "docker-compose.yml",
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_verified": false,
-        "line_number": 19
-      }
-    ],
-    "src/authentication/mitol/authentication/settings/djoser_settings.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/authentication/mitol/authentication/settings/djoser_settings.py",
-        "hashed_secret": "09edaaba587f94f60fbb5cee2234507bcb883cc2",
-        "is_verified": false,
-        "line_number": 5
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/authentication/mitol/authentication/settings/djoser_settings.py",
-        "hashed_secret": "52fb4e0da28167789e40c7b679581e44d097f379",
-        "is_verified": false,
-        "line_number": 27
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/authentication/mitol/authentication/settings/djoser_settings.py",
-        "hashed_secret": "2fdbeb6bd95c83bc63d5e91ee5a4806343d1b4ed",
-        "is_verified": false,
-        "line_number": 30
-      }
-    ],
     "src/mail/mitol/mail/templates/mail/email_debugger.html": [
       {
         "type": "Base64 High Entropy String",
@@ -232,29 +179,6 @@
         "line_number": 14
       }
     ],
-    "testapp/main/settings/shared.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "testapp/main/settings/shared.py",
-        "hashed_secret": "8f2581750096043a1c68bedea8cfa6e13ad1a2e4",
-        "is_verified": false,
-        "line_number": 40
-      },
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "testapp/main/settings/shared.py",
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_verified": false,
-        "line_number": 122
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "testapp/main/settings/shared.py",
-        "hashed_secret": "9bc34549d565d9505b287de0cd20ac77be1d3f2c",
-        "is_verified": false,
-        "line_number": 202
-      }
-    ],
     "testapp/main/settings/test.py": [
       {
         "type": "Secret Keyword",
@@ -262,15 +186,6 @@
         "hashed_secret": "6367c48dd193d56ea7b0baad25b19455e529f5ee",
         "is_verified": false,
         "line_number": 9
-      }
-    ],
-    "tests/common/utils/test_urls.py": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "tests/common/utils/test_urls.py",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 18
       }
     ],
     "tests/digitalcredentials/test_backend.py": [
@@ -290,34 +205,7 @@
         "is_verified": false,
         "line_number": 60
       }
-    ],
-    "tests/google_sheets/test_api.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/google_sheets/test_api.py",
-        "hashed_secret": "a0281cd072cea8e80e7866b05dc124815760b6c9",
-        "is_verified": false,
-        "line_number": 46
-      }
-    ],
-    "tests/google_sheets/test_utils.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/google_sheets/test_utils.py",
-        "hashed_secret": "43ed4c2d8375dfc89e3dc8c917f404b9481d355b",
-        "is_verified": false,
-        "line_number": 15
-      }
-    ],
-    "tests/google_sheets/test_views.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/google_sheets/test_views.py",
-        "hashed_secret": "43ed4c2d8375dfc89e3dc8c917f404b9481d355b",
-        "is_verified": false,
-        "line_number": 29
-      }
     ]
   },
-  "generated_at": "2025-02-26T21:58:39Z"
+  "generated_at": "2025-03-17T12:30:31Z"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ authors = [
 dependencies = [
   "mitol-django-common",
   "mitol-django-mail",
-  "mitol-django-authentication",
+  'mitol-django-authentication[touchstone]; python_version < "3.13"',
+  'mitol-django-authentication; python_version >= "3.13"',
   "mitol-django-digitalcredentials",
   "mitol-django-geoip",
   "mitol-django-google_sheets",

--- a/src/authentication/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/authentication/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,44 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+- Support for SAML/Touchstone authentication and views.
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/authentication/pyproject.toml
+++ b/src/authentication/pyproject.toml
@@ -12,11 +12,16 @@ dependencies = [
   "mitol-django-common",
   "mitol-django-mail",
   "social-auth-app-django>=5.4.0",
-  "python3-saml>=1.10.1"
 ]
 readme = "README.md"
 license = "BSD-3-Clause"
 requires-python = ">=3.10"
+
+[project.optional-dependencies]
+touchstone = [
+  'python3-saml>=1.10.1; python_version < "3.13"'
+]
+
 
 [tool.bumpver]
 current_version = "2025.2.12"

--- a/src/common/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/common/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/digitalcredentials/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/digitalcredentials/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/geoip/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/geoip/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/google_sheets/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/google_sheets/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/google_sheets_deferrals/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/google_sheets_deferrals/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/google_sheets_refunds/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/google_sheets_refunds/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/hubspot_api/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/hubspot_api/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/mail/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/mail/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/oauth_toolkit_extensions/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/oauth_toolkit_extensions/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/olposthog/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/olposthog/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/openedx/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/openedx/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/payment_gateway/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/payment_gateway/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/transcoding/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/transcoding/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/uvtestapp/changelog.d/20250317_083551_nlevesq_python_3_13.md
+++ b/src/uvtestapp/changelog.d/20250317_083551_nlevesq_python_3_13.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+- Support for Python 3.13
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/testapp/main/settings/shared.py
+++ b/testapp/main/settings/shared.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
 import os
+import sys
 
 import dj_database_url
 from mitol.common.envs import get_string, import_settings_modules, init_app_settings
@@ -127,10 +128,10 @@ DEFAULT_DATABASE_CONFIG = dj_database_url.parse(
 
 DATABASES = {"default": DEFAULT_DATABASE_CONFIG}
 
-AUTHENTICATION_BACKENDS = (
-    "django.contrib.auth.backends.ModelBackend",
-    "social_core.backends.saml.SAMLAuth",
-)
+AUTHENTICATION_BACKENDS = ("django.contrib.auth.backends.ModelBackend",)
+
+if sys.version_info <= (3, 13):
+    AUTHENTICATION_BACKENDS += ("social_core.backends.saml.SAMLAuth",)
 
 
 # Password validation

--- a/testapp/main/urls.py
+++ b/testapp/main/urls.py
@@ -1,5 +1,7 @@
 """testapp URL Configuration"""
 
+import sys
+
 from django.contrib import admin
 from django.urls import include, path
 from oauth2_provider.urls import base_urlpatterns
@@ -15,7 +17,6 @@ urlpatterns = [
     path("api/", include("mitol.digitalcredentials.urls")),
     path("api/", include("mitol.google_sheets.urls")),
     path("api/", include("mitol.mail.urls")),
-    path("", include("mitol.authentication.urls.saml")),
     path("", include("mitol.authentication.urls.djoser_urls")),
     path("", include("social_django.urls", namespace="social")),
     path(
@@ -25,3 +26,8 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("mitol.transcoding.urls")),
 ]
+
+if sys.version_info < (3, 13):
+    urlpatterns += [
+        path("", include("mitol.authentication.urls.saml")),
+    ]

--- a/tests/authentication/views/test_saml.py
+++ b/tests/authentication/views/test_saml.py
@@ -1,8 +1,14 @@
 """SAML view tests"""
 
+import sys
 from xml.etree import ElementTree
 
+import pytest
 from django.urls import reverse
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info >= (3, 13), reason="Not supported in python >= 3.13"
+)
 
 
 def test_saml_metadata(settings, client):

--- a/uv.lock
+++ b/uv.lock
@@ -1220,8 +1220,12 @@ dependencies = [
     { name = "djoser" },
     { name = "mitol-django-common" },
     { name = "mitol-django-mail" },
-    { name = "python3-saml" },
     { name = "social-auth-app-django" },
+]
+
+[package.optional-dependencies]
+touchstone = [
+    { name = "python3-saml", marker = "python_full_version < '3.13'" },
 ]
 
 [package.metadata]
@@ -1233,9 +1237,10 @@ requires-dist = [
     { name = "djoser", specifier = "==2.3.1" },
     { name = "mitol-django-common", editable = "src/common" },
     { name = "mitol-django-mail", editable = "src/mail" },
-    { name = "python3-saml", specifier = ">=1.10.1" },
+    { name = "python3-saml", marker = "python_full_version < '3.13' and extra == 'touchstone'", specifier = ">=1.10.1" },
     { name = "social-auth-app-django", specifier = ">=5.4.0" },
 ]
+provides-extras = ["touchstone"]
 
 [[package]]
 name = "mitol-django-common"
@@ -1633,6 +1638,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "mitol-django-authentication" },
+    { name = "mitol-django-authentication", extra = ["touchstone"], marker = "python_full_version < '3.13'" },
     { name = "mitol-django-common" },
     { name = "mitol-django-digitalcredentials" },
     { name = "mitol-django-geoip" },
@@ -1681,7 +1687,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mitol-django-authentication", editable = "src/authentication" },
+    { name = "mitol-django-authentication", marker = "python_full_version >= '3.13'", editable = "src/authentication" },
+    { name = "mitol-django-authentication", extras = ["touchstone"], marker = "python_full_version < '3.13'", editable = "src/authentication" },
     { name = "mitol-django-common", editable = "src/common" },
     { name = "mitol-django-digitalcredentials", editable = "src/digitalcredentials" },
     { name = "mitol-django-geoip", editable = "src/geoip" },
@@ -2166,9 +2173,9 @@ name = "python3-saml"
 version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "isodate" },
-    { name = "lxml" },
-    { name = "xmlsec" },
+    { name = "isodate", marker = "python_full_version < '3.13'" },
+    { name = "lxml", marker = "python_full_version < '3.13'" },
+    { name = "xmlsec", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5d/98/6e0268c3a9893af3d4c5cf670183e0314cd6b5cb034a612d6a7cc5060df8/python3-saml-1.16.0.tar.gz", hash = "sha256:97c9669aecabc283c6e5fb4eb264f446b6e006f5267d01c9734f9d8bffdac133", size = 83468 }
 wheels = [
@@ -2598,7 +2605,7 @@ name = "xmlsec"
 version = "1.3.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "lxml" },
+    { name = "lxml", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/5b/244459b51dfe91211c1d9ec68fb5307dfc51e014698f52de575d25f753e0/xmlsec-1.3.14.tar.gz", hash = "sha256:934f804f2f895bcdb86f1eaee236b661013560ee69ec108d29cdd6e5f292a2d9", size = 68854 }
 wheels = [


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Related to https://github.com/mitodl/hq/issues/6821

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds support for python 3.13 and removes support for SAML/Touchstone in the auth package for python >= 3.13. Any applications still using SAML/Touchstone that want to upgrade past 3.12 will need to address https://github.com/mitodl/hq/issues/6821.

I also made a change to the changelog `check` command so that it considers changes to the top level `uv.lock` as valid changes to _any_ subproject so that you can add a changelog without the check failing for things like adding/removing python versions.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

You should be able to run the tests under any python version >= 3.10 (the github actions test all of these, so you probably only need to spot check 3.13 and one other version):

```shell
uv python pin [3.10|3.11|3.12|3.13]
uv sync
uv run pytest
```
