### PR TITLE
Umar/7039 fix mp4 exlude

### DIFF
--- a/src/transcoding/changelog.d/20250410_101632_umar.hassan8_7039_fix_mp4_exlude.md
+++ b/src/transcoding/changelog.d/20250410_101632_umar.hassan8_7039_fix_mp4_exlude.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- Fixed the exclude mp4 param for group settings
+
+-->
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/transcoding/mitol/transcoding/api.py
+++ b/src/transcoding/mitol/transcoding/api.py
@@ -102,6 +102,7 @@ def add_group_settings(
             for group in output_groups
             if group["OutputGroupSettings"]["Type"] != GroupSettings.FILE_GROUP_SETTINGS
         ]
+        job_dict["Settings"]["OutputGroups"] = output_groups
 
     for group in output_groups:
         output_group_settings = group["OutputGroupSettings"]

--- a/uv.lock
+++ b/uv.lock
@@ -1613,7 +1613,7 @@ requires-dist = [
 
 [[package]]
 name = "mitol-django-transcoding"
-version = "2025.3.17"
+version = "2025.4.8"
 source = { editable = "src/transcoding" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/7039

### Description (What does it do?)
Added handling for multiple media profiles in OVS

### Testing
This will be tested along with `https://github.com/mitodl/ocw-studio/pull/2421` after publishing.

Anyone interested in testing it locally can do so using the `ocw-studio` repository, as follows:
1. switch to this branch `umar/7039-update-transcoding-app` in the `ol-django` repository.
2. run the following: 
```
docker-compose build
docker-compose run --rm -ti shell bash

# inside shell
uv build --package mitol-django-transcoding
```
3. check that you have a `mitol_django_transcoding-xxxx.x.xx.tar.gz` file in `dist/`
4. Move `list/mitol_django_transcoding-xxxx.x.xx.tar.gz` to ocw-studio repository.
5.  switch to branch `umar/6717-refactor-transcoding-job-code` in ocw-studio.
6. Spin up containers after rebuilding: `docker-compose up -d --build`
7. Test the transcoding functionality using the instructions in readme or [here](https://github.com/mitodl/ocw-studio/pull/469)