### PR TITLE
Add create_userinfo_header, fix issue with disabling middleware

### DIFF
--- a/src/apigateway/changelog.d/20250414_152653_jkachel_add_apigateway_test_helper.md
+++ b/src/apigateway/changelog.d/20250414_152653_jkachel_add_apigateway_test_helper.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+
+### Added
+
+- Added create_userinfo_header to assist with creating test clients.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/apigateway/mitol/apigateway/middleware.py
+++ b/src/apigateway/mitol/apigateway/middleware.py
@@ -27,7 +27,7 @@ class ApisixUserMiddleware(RemoteUserMiddleware):
         log.debug("ApisixUserMiddleware.process_request: started")
 
         if settings.MITOL_APIGATEWAY_DISABLE_MIDDLEWARE:
-            return super().process_request(request)
+            return self.get_response(request)
 
         if request.META.get(settings.MITOL_APIGATEWAY_USERINFO_HEADER_NAME):
             new_header = get_user_id_from_userinfo_header(request)

--- a/src/apigateway/mitol/apigateway/settings/__init__.py
+++ b/src/apigateway/mitol/apigateway/settings/__init__.py
@@ -22,8 +22,7 @@ MITOL_APIGATEWAY_USERINFO_MODEL_MAP = {
     # Mappings to the user model.
     "user_fields": {
         # Keys are data returned from the API gateway.
-        # Values are tuple of model name (from above) and field name.
-        # The base model is "user".
+        # Values are the user object field name.
         "preferred_username": "username",
         "email": "email",
         "sub": "global_id",

--- a/tests/apigateway/test_api.py
+++ b/tests/apigateway/test_api.py
@@ -1,5 +1,8 @@
 """Tests for the Apigateway API."""
 
+import base64
+import json
+
 import faker
 import pytest
 from django.conf import settings
@@ -47,3 +50,14 @@ def test_get_username(obj_type):
     decoded = api.get_username_from_userinfo_header(request)
     assert decoded != user_info[settings.MITOL_APIGATEWAY_USERINFO_ID_FIELD]
     assert decoded == user.username
+
+
+def test_create_userinfo_header():
+    """Test that the userinfo header gets created properly."""
+
+    user = SsoUserFactory.create()
+    header_name = settings.MITOL_APIGATEWAY_USERINFO_HEADER_NAME.replace("HTTP_", "")
+    header_data = api.create_userinfo_header(user)
+    result = json.loads(base64.b64decode(header_data[header_name]).decode())
+
+    assert result["sub"] == user.global_id

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1306,6 +1307,7 @@ requires-dist = [
     { name = "social-auth-app-django", specifier = ">=5.4.0" },
     { name = "xmlsec", marker = "python_full_version < '3.13' and extra == 'touchstone'", specifier = "<1.3.15" },
 ]
+provides-extras = ["touchstone"]
 
 [[package]]
 name = "mitol-django-common"
@@ -1613,7 +1615,7 @@ requires-dist = [
 
 [[package]]
 name = "mitol-django-transcoding"
-version = "2025.4.8"
+version = "2025.4.10"
 source = { editable = "src/transcoding" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

When using an `APIClient` for testing authenticated routes, you can use `force_authenticate` to force it to be authenticated as a particular user. This is usually fine, but for apps that use `apigateway`, it'll fail. This is because there's no user info header, so the middleware logs you out.

This adds a `create_userinfo_header` API function that can be used to generate the header for `APIClient`. 

Additionally, the middleware did disable when using the `MITOL_APIGATEWAY_DISABLE_MIDDLEWARE` option but it did this by passing the request back to `RemoteUserMiddleware`. This meant it ran as per usual. Instead, now this just returns the response as if we did any processing at all.

### How can this be tested?

Automated tests should pass.

This is pretty simple, though - it just takes the supplied user object and pulls the data out of it according to the field map that's already in there, and makes a dict that can be passed into APIClient. So, you should be able to run it and see results that you expect. Note that the data will be a JSON object that has been base64 encoded.

