### PR TITLE
Make remote user record creation atomic

### DIFF
--- a/src/apigateway/changelog.d/20250425_151315_nlevesq_atomic_backend_authenticate.md
+++ b/src/apigateway/changelog.d/20250425_151315_nlevesq_atomic_backend_authenticate.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Made authentication for users transactional to avoid incomplete state.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/uv.lock
+++ b/uv.lock
@@ -1255,7 +1255,7 @@ wheels = [
 
 [[package]]
 name = "mitol-django-apigateway"
-version = "2025.4.15"
+version = "2025.4.25"
 source = { editable = "src/apigateway" }
 dependencies = [
     { name = "channels" },


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/7194

### Description (What does it do?)
<!--- Describe your changes in detail -->
Wraps the backend authentication in a `transaction.atomic()`.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This is an edge case, but if for whatever reason the creation of the user fails, we want to make sure a user doesn't end up in a partial state.