### PR TITLE
Umar/7287 filter thumbnail group

### DIFF
--- a/src/transcoding/changelog.d/20250509_044403_umar.hassan8_7287_filter_thumbnail_group.md
+++ b/src/transcoding/changelog.d/20250509_044403_umar.hassan8_7287_filter_thumbnail_group.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+### Added
+
+- Added filter for thumbnail groupss
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/transcoding/mitol/transcoding/api.py
+++ b/src/transcoding/mitol/transcoding/api.py
@@ -136,14 +136,21 @@ def add_group_settings(job_dict: dict, file_config: FileConfig) -> None:
     Args:
         job_dict (dict): MediaConvert job dictionary.
         file_config (FileConfig): Configuration for file paths and settings.
-
     """
     output_groups = job_dict["Settings"]["OutputGroups"]
+    exclude_mp4 = file_config.group_settings.get("exclude_mp4", False)
+    exclude_thumbnail = file_config.group_settings.get("exclude_thumbnail", False)
 
-    if file_config.group_settings.get("exclude_mp4", False):
-        filtered_groups = filter_mp4_groups(output_groups)
-        job_dict["Settings"]["OutputGroups"] = filtered_groups
-        output_groups = filtered_groups
+    # Apply all filters sequentially
+    if exclude_mp4:
+        output_groups = filter_mp4_groups(output_groups)
+
+    if exclude_thumbnail:
+        output_groups = [
+            group for group in output_groups if not is_thumbnail_group(group)
+        ]
+
+    job_dict["Settings"]["OutputGroups"] = output_groups
 
     for group in output_groups:
         output_group_settings = group["OutputGroupSettings"]


### PR DESCRIPTION
### What are the relevant tickets?
part of https://github.com/mitodl/hq/issues/7287

### Description (What does it do?)
this adds filtering for thumbnail groups based on the provided parameter

### How can this be tested?
This will be tested along with `https://github.com/mitodl/odl-video-service/pull/1200`.

Anyone interested in testing it locally can do so using the `old-video-service` repository, as follows:
1. Switch to this branch in the local repository.
2. Run the following: 
```
docker-compose build
docker-compose run --rm -ti shell bash

# inside shell
uv build --package mitol-django-transcoding
```
3. Check that you have a `mitol_django_transcoding-xxxx.x.xx.tar.gz` file in `dist/`
4. Move `dist/mitol_django_transcoding-xxxx.x.xx.tar.gz` to OVS local repository.
5. Switch to the `umar/7287-post-release-retranscoding-s3-path` branch in the OVS local repository.
6. Spin up containers after rebuilding: `docker-compose up -d --build`
7. Add a transcoding job by adding video to a collection in ovs app
8. Verify the Encode Job data from the Django admin
9. Add a retranscoding job to check that it does not add a thumbnail in the results