### PR TITLE
removed handling for general exception for boto3 in transcoding app

### DIFF
--- a/src/transcoding/changelog.d/20250519_113212_umar.hassan8_7328_fix_exception_for_boto3_in_transcoding_app.md
+++ b/src/transcoding/changelog.d/20250519_113212_umar.hassan8_7328_fix_exception_for_boto3_in_transcoding_app.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+### Changed
+
+- removed exception handling for transcoding app
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/transcoding/mitol/transcoding/api.py
+++ b/src/transcoding/mitol/transcoding/api.py
@@ -55,17 +55,12 @@ def media_convert_job(  # noqa: PLR0913
     # Make MediaConvert job
     job_dict = make_media_convert_job(file_config)
 
-    try:
-        client = boto3.client(
-            "mediaconvert",
-            region_name=settings.AWS_REGION,
-            endpoint_url=settings.VIDEO_S3_TRANSCODE_ENDPOINT,
-        )
-        return client.create_job(**job_dict)
-
-    except Exception as e:
-        err_msg = f"Failed to create MediaConvert client: {e}"
-        raise ValueError(err_msg) from e
+    client = boto3.client(
+        "mediaconvert",
+        region_name=settings.AWS_REGION,
+        endpoint_url=settings.VIDEO_S3_TRANSCODE_ENDPOINT,
+    )
+    return client.create_job(**job_dict)
 
 
 def make_media_convert_job(file_config: FileConfig) -> dict:


### PR DESCRIPTION
### What are the relevant tickets?
part of https://github.com/mitodl/hq/issues/7328

### Description (What does it do?)
this adds filtering for thumbnail groups based on the provided parameter

### How can this be tested?

Anyone interested in testing it locally can do so using the `ocw-studio` repository, as follows:
1. Switch to this branch in the local repository.
2. Run the following: 
```
docker-compose build
docker-compose run --rm -ti shell bash

# inside shell
uv build --package mitol-django-transcoding
```
3. Check that you have a `mitol_django_transcoding-xxxx.x.xx.tar.gz` file in `dist/`
4. Move `dist/mitol_django_transcoding-xxxx.x.xx.tar.gz` to OCW studio local repository.
5. Switch to the `master` branch in the OCW-Studio local repository.
6. Spin up containers after rebuilding: `docker-compose up -d --build`
7. Add a transcoding job by adding video via GitHub flow
8. Verify the Job data from the Django admin