### PR TITLE
feat: add reusable username generation utilities

### DIFF
--- a/src/common/mitol/common/constants.py
+++ b/src/common/mitol/common/constants.py
@@ -1,0 +1,21 @@
+"""common constants"""
+
+USERNAME_SEPARATOR = "-"
+# Characters that should be replaced by the specified separator character
+USERNAME_SEPARATOR_REPLACE_CHARS = "\\s_"
+# Characters that should be removed entirely from the full name to create the username
+USERNAME_INVALID_CHAR_PATTERN = (
+    rf"[^\w{USERNAME_SEPARATOR_REPLACE_CHARS}{USERNAME_SEPARATOR}]|[\d]"
+)
+
+USERNAME_TURKISH_I_CHARS = r"[ıİ]"
+USERNAME_TURKISH_I_CHARS_REPLACEMENT = "i"
+
+# Pattern for chars to replace with a single separator. The separator character itself
+# is also included in this pattern so repeated separators are squashed down.
+USERNAME_SEPARATOR_REPLACE_PATTERN = (
+    rf"[{USERNAME_SEPARATOR_REPLACE_CHARS}{USERNAME_SEPARATOR}]+"
+)
+
+USERNAME_MAX_LEN = 30
+USERNAME_COLLISION_ATTEMPTS = 10

--- a/src/common/mitol/common/utils/__init__.py
+++ b/src/common/mitol/common/utils/__init__.py
@@ -7,5 +7,5 @@ from mitol.common.utils.datetime import *  # noqa: F403
 from mitol.common.utils.http_requests import *  # noqa: F403
 from mitol.common.utils.serializers import *  # noqa: F403
 from mitol.common.utils.urls import *  # noqa: F403
-from mitol.common.utils.webpack import *  # noqa: F403
 from mitol.common.utils.user import *  # noqa: F403
+from mitol.common.utils.webpack import *  # noqa: F403

--- a/src/common/mitol/common/utils/__init__.py
+++ b/src/common/mitol/common/utils/__init__.py
@@ -8,3 +8,4 @@ from mitol.common.utils.http_requests import *  # noqa: F403
 from mitol.common.utils.serializers import *  # noqa: F403
 from mitol.common.utils.urls import *  # noqa: F403
 from mitol.common.utils.webpack import *  # noqa: F403
+from mitol.common.utils.user import *  # noqa: F403

--- a/src/common/mitol/common/utils/helpers.py
+++ b/src/common/mitol/common/utils/helpers.py
@@ -2,7 +2,7 @@
 
 
 def max_or_none(iterable):
-    """Returns the max of some iterable, or None if the iterable has no items
+    """Return the max of some iterable, or None if the iterable has no items
 
     Args:
         iterable (iterable): Some iterable

--- a/src/common/mitol/common/utils/helpers.py
+++ b/src/common/mitol/common/utils/helpers.py
@@ -1,0 +1,16 @@
+"""helper functions for utilities"""
+
+
+def max_or_none(iterable):
+    """
+    Returns the max of some iterable, or None if the iterable has no items
+
+    Args:
+        iterable (iterable): Some iterable
+    Returns:
+        max item or None
+    """
+    try:
+        return max(iterable)
+    except ValueError:
+        return None

--- a/src/common/mitol/common/utils/helpers.py
+++ b/src/common/mitol/common/utils/helpers.py
@@ -2,8 +2,7 @@
 
 
 def max_or_none(iterable):
-    """
-    Returns the max of some iterable, or None if the iterable has no items
+    """Returns the max of some iterable, or None if the iterable has no items
 
     Args:
         iterable (iterable): Some iterable

--- a/src/common/mitol/common/utils/user.py
+++ b/src/common/mitol/common/utils/user.py
@@ -1,0 +1,209 @@
+"""User utilities"""
+
+import logging
+import re
+
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError
+
+from common.constants import (
+    USERNAME_INVALID_CHAR_PATTERN,
+    USERNAME_TURKISH_I_CHARS,
+    USERNAME_TURKISH_I_CHARS_REPLACEMENT,
+    USERNAME_SEPARATOR_REPLACE_PATTERN,
+    USERNAME_SEPARATOR,
+    USERNAME_MAX_LEN,
+    USERNAME_COLLISION_ATTEMPTS,
+)
+from .helpers import max_or_none
+
+log = logging.getLogger(__name__)
+
+
+def _reformat_for_username(string):
+    """
+    Removes/substitutes characters in a string to make it suitable as a username value
+
+    Args:
+        string (str): A string
+    Returns:
+        str: A version of the string with username-appropriate characters
+    """
+    cleaned_string = re.sub(USERNAME_INVALID_CHAR_PATTERN, "", string)
+    cleaned_string = re.sub(
+        USERNAME_TURKISH_I_CHARS, USERNAME_TURKISH_I_CHARS_REPLACEMENT, cleaned_string
+    )
+    return (
+        re.sub(USERNAME_SEPARATOR_REPLACE_PATTERN, USERNAME_SEPARATOR, cleaned_string)
+        .lower()
+        .strip(USERNAME_SEPARATOR)
+    )
+
+
+def _is_duplicate_username_error(exc):
+    """
+    Return True if the given exception indicates that there was an attempt to save a User record with an
+    already-existing username.
+
+    Args:
+        exc (Exception): An exception
+
+    Returns:
+        bool: Whether or not the exception indicates a duplicate username error
+    """
+    return re.search(r"\(username\)=\([^\s]+\) already exists", str(exc)) is not None
+
+
+def _find_available_username(
+    initial_username_base, model=None, username_field="username", max_length=USERNAME_MAX_LEN
+):
+    """
+    Return a username with the lowest possible suffix given some base username. If the applied suffix
+    makes the username longer than the username max length, characters are removed from the
+    right of the username to make room.
+
+    EXAMPLES:
+    initial_username_base = "johndoe"
+        Existing usernames = "johndoe"
+        Return value = "johndoe1"
+    initial_username_base = "johndoe"
+        Existing usernames = "johndoe", "johndoe1" through "johndoe5"
+        Return value = "johndoe6"
+    initial_username_base = "abcdefghijklmnopqrstuvwxyz" (26 characters, assuming 26 character max)
+        Existing usernames = "abcdefghijklmnopqrstuvwxyz"
+        Return value = "abcdefghijklmnopqrstuvwxy1"
+    initial_username_base = "abcdefghijklmnopqrstuvwxy" (25 characters long, assuming 26 character max)
+        Existing usernames = "abc...y", "abc...y1" through "abc...y9"
+        Return value = "abcdefghijklmnopqrstuvwx10"
+
+    Args:
+         initial_username_base (str): Base username to start with
+         model: The model class to query (defaults to User model)
+         username_field (str): The field name to use for username queries (defaults to 'username')
+         max_length (int): The maximum allowed username length (defaults to USERNAME_MAX_LEN)
+    Returns:
+        str: An available username
+    """
+    if model is None:
+        model = get_user_model()
+
+    # Keeps track of the number of characters that must be cut from the username to be less than
+    # the username max length when the suffix is applied.
+    letters_to_truncate = 0 if len(initial_username_base) < max_length else 1
+    # Any query for suffixed usernames could come up empty. The minimum suffix will be added to
+    # the username in that case.
+    current_min_suffix = 1
+    while letters_to_truncate < len(initial_username_base):  # noqa: RET503
+        username_base = initial_username_base[
+            0 : len(initial_username_base) - letters_to_truncate
+        ]
+        # Find usernames that match the username base and have a numerical suffix, then find the max suffix
+        filter_kwargs = {f"{username_field}__regex": rf"{username_base}[0-9]+"}
+        existing_usernames = model.objects.filter(
+            **filter_kwargs
+        ).values_list(username_field, flat=True)
+        max_suffix = max_or_none(
+            int(re.search(r"\d+$", username).group()) for username in existing_usernames
+        )
+        if max_suffix is None:
+            return "".join([username_base, str(current_min_suffix)])
+        else:
+            next_suffix = max_suffix + 1
+            candidate_username = "".join([username_base, str(next_suffix)])
+            # If the next suffix adds a digit and causes the username to exceed the character limit,
+            # keep searching.
+            if len(candidate_username) <= max_length:
+                return candidate_username
+        # At this point, we know there are no suffixes left to add to this username base that was tried,
+        # so we will need to remove letters from the end of that username base to make room for a longer
+        # suffix.
+        letters_to_truncate = letters_to_truncate + 1
+        available_suffix_digits = max_length - (
+            len(initial_username_base) - letters_to_truncate
+        )
+        # If there is space for 4 digits for the suffix, the minimum value it could be is 1000, or 10^3
+        current_min_suffix = 10 ** (available_suffix_digits - 1)
+
+
+def usernameify(full_name, email="", max_length=USERNAME_MAX_LEN):
+    """
+    Public API for username generation
+    Generate a username based on a full name, or an email address as a fallback.
+
+    Args:
+        full_name (str): A full name (i.e.: User.name)
+        email (str): An email address to use as a fallback if the full name produces
+            a blank username
+        max_length (int): The maximum allowed username length (defaults to USERNAME_MAX_LEN)
+    Returns:
+        str: A generated username
+    Raises:
+        ValueError: Raised if generated username was blank after trying both the
+            full name and email
+    """
+    username = _reformat_for_username(full_name)
+
+    if not username and email:
+        log.error(
+            "User's full name could not be used to generate a username (full name: '%s'). "
+            "Trying email instead...",
+            full_name,
+        )
+        username = _reformat_for_username(email.split("@")[0])
+    if not username:
+        raise ValueError(
+            "Username could not be generated (full_name: '{}', email: '{}')".format(  # noqa: EM103, UP032
+                full_name, email
+            )
+        )
+    return username[0:max_length]
+
+
+def create_user_with_generated_username(
+    serializer,
+    initial_username,
+    username_field,
+    max_length,
+    model=None,
+    attempts_limit=USERNAME_COLLISION_ATTEMPTS,
+):
+    """
+    Public API for user creation with auto-generated username
+    Creates a User with a given username, and if there is a User that already has that username,
+    finds an available username and reattempts the User creation.
+
+    Args:
+        serializer: A serializer instance that has been instantiated
+            with user data and has passed initial validation
+        initial_username (str): The initial username to attempt to save the User with
+        username_field (str): The field name to use for the username
+        max_length (int): The maximum allowed username length
+        model: The model class to pass to find_username_func (defaults to None)
+        attempts_limit (int): Maximum number of attempts to create user
+
+    Returns:
+        User or None: The created User (or None if the User could not be created in the
+            number of retries allowed)
+    """
+    created_user = None
+    username = initial_username
+    attempts = 0
+
+    if len(username) < 2:  # noqa: PLR2004
+        username = username + "11"
+
+    while created_user is None and attempts < attempts_limit:
+        try:
+            created_user = serializer.save(username=username)
+        except IntegrityError as exc:
+            if not _is_duplicate_username_error(exc):
+                raise
+            username = _find_available_username(
+                initial_username,
+                model=model,
+                username_field=username_field,
+                max_length=max_length
+            )
+        finally:
+            attempts += 1
+    return created_user

--- a/src/common/mitol/common/utils/user.py
+++ b/src/common/mitol/common/utils/user.py
@@ -75,14 +75,14 @@ def _find_available_username(
     initial_username_base = "johndoe"
         Existing usernames = "johndoe", "johndoe1" through "johndoe5"
         Return value = "johndoe6"
-    initial_username_base = "abcdefghijklmnopqrstuvwxyz"
-        (26 characters, assuming 26 character max)
+    initial_username_base = "abcdefghijklmnopqrstuvwxyz"  (26 characters,
+        assuming 26 character max)
         Existing usernames = "abcdefghijklmnopqrstuvwxyz"
-        Return value = "abcdefghijklmnopqrstuvwxy1"  # pragma: allowlist secre
+        Return value = "abcdefghijklmnopqrstuvwxy1"  # pragma: allowlist secret
     initial_username_base = "abcdefghijklmnopqrstuvwxy"
         (25 characters long, assuming 26 character max)
         Existing usernames = "abc...y", "abc...y1" through "abc...y9"
-        Return value = "abcdefghijklmnopqrstuvwx10"  # pragma: allowlist secre
+        Return value = "abcdefghijklmnopqrstuvwx10"  # pragma: allowlist secret
 
     Args:
          initial_username_base (str): Base username to start with

--- a/src/common/mitol/common/utils/user.py
+++ b/src/common/mitol/common/utils/user.py
@@ -6,7 +6,7 @@ import re
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError
 
-from common.constants import (
+from mitol.common.constants import (
     USERNAME_INVALID_CHAR_PATTERN,
     USERNAME_TURKISH_I_CHARS,
     USERNAME_TURKISH_I_CHARS_REPLACEMENT,
@@ -40,7 +40,7 @@ def _reformat_for_username(string):
     )
 
 
-def _is_duplicate_username_error(exc):
+def is_duplicate_username_error(exc):
     """
     Return True if the given exception indicates that there was an attempt to save a User record with an
     already-existing username.
@@ -196,7 +196,7 @@ def create_user_with_generated_username(
         try:
             created_user = serializer.save(username=username)
         except IntegrityError as exc:
-            if not _is_duplicate_username_error(exc):
+            if not is_duplicate_username_error(exc):
                 raise
             username = _find_available_username(
                 initial_username,

--- a/src/common/mitol/common/utils/user.py
+++ b/src/common/mitol/common/utils/user.py
@@ -7,14 +7,15 @@ from django.contrib.auth import get_user_model
 from django.db import IntegrityError
 
 from mitol.common.constants import (
+    USERNAME_COLLISION_ATTEMPTS,
     USERNAME_INVALID_CHAR_PATTERN,
+    USERNAME_MAX_LEN,
+    USERNAME_SEPARATOR,
+    USERNAME_SEPARATOR_REPLACE_PATTERN,
     USERNAME_TURKISH_I_CHARS,
     USERNAME_TURKISH_I_CHARS_REPLACEMENT,
-    USERNAME_SEPARATOR_REPLACE_PATTERN,
-    USERNAME_SEPARATOR,
-    USERNAME_MAX_LEN,
-    USERNAME_COLLISION_ATTEMPTS,
 )
+
 from .helpers import max_or_none
 
 log = logging.getLogger(__name__)
@@ -98,7 +99,7 @@ def _find_available_username(
         model = get_user_model()
 
     # Keeps track of the number of characters that must be cut from the
-    # username to be less than the username max length when the 
+    # username to be less than the username max length when the
     # suffix is applied.
     letters_to_truncate = 0 if len(initial_username_base) < max_length else 1
     # Any query for suffixed usernames could come up empty. The minimum suffix
@@ -175,7 +176,7 @@ def usernameify(full_name, email="", max_length=USERNAME_MAX_LEN):
     return username[0:max_length]
 
 
-def create_user_with_generated_username(
+def create_user_with_generated_username(  # noqa: PLR0913
     serializer,
     initial_username,
     username_field,
@@ -212,7 +213,7 @@ def create_user_with_generated_username(
     while created_user is None and attempts < attempts_limit:
         try:
             created_user = serializer.save(username=username)
-        except IntegrityError as exc:
+        except IntegrityError as exc:  # noqa: PERF203
             if not is_duplicate_username_error(exc):
                 raise
             username = _find_available_username(

--- a/src/common/mitol/common/utils/user.py
+++ b/src/common/mitol/common/utils/user.py
@@ -32,12 +32,12 @@ def _reformat_for_username(string):
     """
     cleaned_string = re.sub(USERNAME_INVALID_CHAR_PATTERN, "", string)
     cleaned_string = re.sub(
-        USERNAME_TURKISH_I_CHARS, USERNAME_TURKISH_I_CHARS_REPLACEMENT,
+        USERNAME_TURKISH_I_CHARS,
+        USERNAME_TURKISH_I_CHARS_REPLACEMENT,
         cleaned_string,
     )
     return (
-        re.sub(USERNAME_SEPARATOR_REPLACE_PATTERN, USERNAME_SEPARATOR,
-               cleaned_string)
+        re.sub(USERNAME_SEPARATOR_REPLACE_PATTERN, USERNAME_SEPARATOR, cleaned_string)
         .lower()
         .strip(USERNAME_SEPARATOR)
     )
@@ -53,9 +53,7 @@ def is_duplicate_username_error(exc):
     Returns:
         bool: Whether or not the exception indicates a duplicate username error
     """
-    return re.search(
-        r"\(username\)=\([^\s]+\) already exists",
-        str(exc)) is not None
+    return re.search(r"\(username\)=\([^\s]+\) already exists", str(exc)) is not None
 
 
 def _find_available_username(
@@ -107,7 +105,7 @@ def _find_available_username(
     current_min_suffix = 1
     while letters_to_truncate < len(initial_username_base):  # noqa: RET503
         username_base = initial_username_base[
-            0: len(initial_username_base) - letters_to_truncate
+            0 : len(initial_username_base) - letters_to_truncate
         ]
         # Find usernames that match the username base and have a numerical
         # suffix, then find the max suffix
@@ -116,8 +114,7 @@ def _find_available_username(
             username_field, flat=True
         )
         max_suffix = max_or_none(
-            int(re.search(r"\d+$", username).group())
-            for username in existing_usernames
+            int(re.search(r"\d+$", username).group()) for username in existing_usernames
         )
         if max_suffix is None:
             return "".join([username_base, str(current_min_suffix)])
@@ -154,7 +151,7 @@ def usernameify(full_name, email="", max_length=USERNAME_MAX_LEN):
     Returns:
         str: A generated username
     Raises:
-        ValueError: Raised if generated username was blank after trying both 
+        ValueError: Raised if generated username was blank after trying both
             the full name and email
     """
     username = _reformat_for_username(full_name)

--- a/src/common/mitol/common/utils/user.py
+++ b/src/common/mitol/common/utils/user.py
@@ -1,4 +1,4 @@
-"""User utilities"""
+"""User utilities."""
 
 import logging
 import re
@@ -21,8 +21,8 @@ log = logging.getLogger(__name__)
 
 
 def _reformat_for_username(string):
-    """
-    Removes/substitutes characters in a string to make it suitable as a username value
+    """Removes/substitutes characters in a string to make it suitable as a
+    username value.
 
     Args:
         string (str): A string
@@ -31,19 +31,20 @@ def _reformat_for_username(string):
     """
     cleaned_string = re.sub(USERNAME_INVALID_CHAR_PATTERN, "", string)
     cleaned_string = re.sub(
-        USERNAME_TURKISH_I_CHARS, USERNAME_TURKISH_I_CHARS_REPLACEMENT, cleaned_string
+        USERNAME_TURKISH_I_CHARS, USERNAME_TURKISH_I_CHARS_REPLACEMENT,
+        cleaned_string,
     )
     return (
-        re.sub(USERNAME_SEPARATOR_REPLACE_PATTERN, USERNAME_SEPARATOR, cleaned_string)
+        re.sub(USERNAME_SEPARATOR_REPLACE_PATTERN, USERNAME_SEPARATOR,
+               cleaned_string)
         .lower()
         .strip(USERNAME_SEPARATOR)
     )
 
 
 def is_duplicate_username_error(exc):
-    """
-    Return True if the given exception indicates that there was an attempt to save a User record with an
-    already-existing username.
+    """Return True if the given exception indicates that there was an attempt
+    to save a User record with an already-existing username.
 
     Args:
         exc (Exception): An exception
@@ -51,16 +52,21 @@ def is_duplicate_username_error(exc):
     Returns:
         bool: Whether or not the exception indicates a duplicate username error
     """
-    return re.search(r"\(username\)=\([^\s]+\) already exists", str(exc)) is not None
+    return re.search(
+        r"\(username\)=\([^\s]+\) already exists",
+        str(exc)) is not None
 
 
 def _find_available_username(
-    initial_username_base, model=None, username_field="username", max_length=USERNAME_MAX_LEN
+    initial_username_base,
+    model=None,
+    username_field="username",
+    max_length=USERNAME_MAX_LEN,
 ):
-    """
-    Return a username with the lowest possible suffix given some base username. If the applied suffix
-    makes the username longer than the username max length, characters are removed from the
-    right of the username to make room.
+    """Return a username with the lowest possible suffix given some
+    base username. If the applied suffix makes the username longer than the
+    username max length, characters are removed from the right of the username
+    to make room.
 
     EXAMPLES:
     initial_username_base = "johndoe"
@@ -69,83 +75,93 @@ def _find_available_username(
     initial_username_base = "johndoe"
         Existing usernames = "johndoe", "johndoe1" through "johndoe5"
         Return value = "johndoe6"
-    initial_username_base = "abcdefghijklmnopqrstuvwxyz" (26 characters, assuming 26 character max)
+    initial_username_base = "abcdefghijklmnopqrstuvwxyz"
+        (26 characters, assuming 26 character max)
         Existing usernames = "abcdefghijklmnopqrstuvwxyz"
-        Return value = "abcdefghijklmnopqrstuvwxy1"
-    initial_username_base = "abcdefghijklmnopqrstuvwxy" (25 characters long, assuming 26 character max)
+        Return value = "abcdefghijklmnopqrstuvwxy1"  # pragma: allowlist secre
+    initial_username_base = "abcdefghijklmnopqrstuvwxy"
+        (25 characters long, assuming 26 character max)
         Existing usernames = "abc...y", "abc...y1" through "abc...y9"
-        Return value = "abcdefghijklmnopqrstuvwx10"
+        Return value = "abcdefghijklmnopqrstuvwx10"  # pragma: allowlist secre
 
     Args:
          initial_username_base (str): Base username to start with
          model: The model class to query (defaults to User model)
-         username_field (str): The field name to use for username queries (defaults to 'username')
-         max_length (int): The maximum allowed username length (defaults to USERNAME_MAX_LEN)
+         username_field (str): The field name to use for username queries
+            (defaults to 'username')
+         max_length (int): The maximum allowed username length
+            (defaults to USERNAME_MAX_LEN)
     Returns:
         str: An available username
     """
     if model is None:
         model = get_user_model()
 
-    # Keeps track of the number of characters that must be cut from the username to be less than
-    # the username max length when the suffix is applied.
+    # Keeps track of the number of characters that must be cut from the
+    # username to be less than the username max length when the 
+    # suffix is applied.
     letters_to_truncate = 0 if len(initial_username_base) < max_length else 1
-    # Any query for suffixed usernames could come up empty. The minimum suffix will be added to
-    # the username in that case.
+    # Any query for suffixed usernames could come up empty. The minimum suffix
+    # will be added to the username in that case.
     current_min_suffix = 1
     while letters_to_truncate < len(initial_username_base):  # noqa: RET503
         username_base = initial_username_base[
-            0 : len(initial_username_base) - letters_to_truncate
+            0: len(initial_username_base) - letters_to_truncate
         ]
-        # Find usernames that match the username base and have a numerical suffix, then find the max suffix
+        # Find usernames that match the username base and have a numerical
+        # suffix, then find the max suffix
         filter_kwargs = {f"{username_field}__regex": rf"{username_base}[0-9]+"}
-        existing_usernames = model.objects.filter(
-            **filter_kwargs
-        ).values_list(username_field, flat=True)
+        existing_usernames = model.objects.filter(**filter_kwargs).values_list(
+            username_field, flat=True
+        )
         max_suffix = max_or_none(
-            int(re.search(r"\d+$", username).group()) for username in existing_usernames
+            int(re.search(r"\d+$", username).group())
+            for username in existing_usernames
         )
         if max_suffix is None:
             return "".join([username_base, str(current_min_suffix)])
         else:
             next_suffix = max_suffix + 1
             candidate_username = "".join([username_base, str(next_suffix)])
-            # If the next suffix adds a digit and causes the username to exceed the character limit,
-            # keep searching.
+            # If the next suffix adds a digit and causes the username to
+            # exceed the character limit, keep searching.
             if len(candidate_username) <= max_length:
                 return candidate_username
-        # At this point, we know there are no suffixes left to add to this username base that was tried,
-        # so we will need to remove letters from the end of that username base to make room for a longer
-        # suffix.
+        # At this point, we know there are no suffixes left to add to this
+        # username base that was tried,
+        # so we will need to remove letters from the end of that username base
+        # to make room for a longer suffix.
         letters_to_truncate = letters_to_truncate + 1
         available_suffix_digits = max_length - (
             len(initial_username_base) - letters_to_truncate
         )
-        # If there is space for 4 digits for the suffix, the minimum value it could be is 1000, or 10^3
+        # If there is space for 4 digits for the suffix, the minimum value it
+        # could be is 1000, or 10^3
         current_min_suffix = 10 ** (available_suffix_digits - 1)
 
 
 def usernameify(full_name, email="", max_length=USERNAME_MAX_LEN):
-    """
-    Public API for username generation
-    Generate a username based on a full name, or an email address as a fallback.
+    """Public API for username generation Generate a username based on a
+    full name, or an email address as a fallback.
 
     Args:
         full_name (str): A full name (i.e.: User.name)
-        email (str): An email address to use as a fallback if the full name produces
-            a blank username
-        max_length (int): The maximum allowed username length (defaults to USERNAME_MAX_LEN)
+        email (str): An email address to use as a fallback if the full name
+            produces a blank username
+        max_length (int): The maximum allowed username length
+            (defaults to USERNAME_MAX_LEN)
     Returns:
         str: A generated username
     Raises:
-        ValueError: Raised if generated username was blank after trying both the
-            full name and email
+        ValueError: Raised if generated username was blank after trying both 
+            the full name and email
     """
     username = _reformat_for_username(full_name)
 
     if not username and email:
         log.error(
-            "User's full name could not be used to generate a username (full name: '%s'). "
+            "User's full name could not be used to generate a username "
+            "(full name: '%s'). "
             "Trying email instead...",
             full_name,
         )
@@ -167,23 +183,24 @@ def create_user_with_generated_username(
     model=None,
     attempts_limit=USERNAME_COLLISION_ATTEMPTS,
 ):
-    """
-    Public API for user creation with auto-generated username
-    Creates a User with a given username, and if there is a User that already has that username,
-    finds an available username and reattempts the User creation.
+    """Public API for user creation with auto-generated username
+    Creates a User with a given username, and if there is a User that already
+    has that username, finds an available username and
+    reattempts the User creation.
 
     Args:
         serializer: A serializer instance that has been instantiated
             with user data and has passed initial validation
-        initial_username (str): The initial username to attempt to save the User with
+        initial_username (str): The initial username to attempt to
+            save the User with
         username_field (str): The field name to use for the username
         max_length (int): The maximum allowed username length
         model: The model class to pass to find_username_func (defaults to None)
         attempts_limit (int): Maximum number of attempts to create user
 
     Returns:
-        User or None: The created User (or None if the User could not be created in the
-            number of retries allowed)
+        User or None: The created User (or None if the User could not be
+        created in the number of retries allowed)
     """
     created_user = None
     username = initial_username
@@ -202,7 +219,7 @@ def create_user_with_generated_username(
                 initial_username,
                 model=model,
                 username_field=username_field,
-                max_length=max_length
+                max_length=max_length,
             )
         finally:
             attempts += 1

--- a/tests/common/utils/test_user.py
+++ b/tests/common/utils/test_user.py
@@ -28,11 +28,10 @@ def test_usernameify(mocker, full_name, email, expected_username):
     temp_username_max_len = 20
     patched_log_error = mocker.patch("mitol.common.utils.user.log.error")
 
-    assert usernameify(
-        full_name,
-        email=email,
-        max_length=temp_username_max_len
-    ) == expected_username
+    assert (
+        usernameify(full_name, email=email, max_length=temp_username_max_len)
+        == expected_username
+    )
     assert patched_log_error.called == bool(email and not full_name)
 
 

--- a/tests/common/utils/test_user.py
+++ b/tests/common/utils/test_user.py
@@ -24,8 +24,8 @@ def test_usernameify(mocker, full_name, email, expected_username):
     """Usernameify should turn a user's name into a username, or use the email if necessary"""
     # Change the username max length to 20 for test data simplicity's sake
     temp_username_max_len = 20
-    mocker.patch("users.utils.USERNAME_MAX_LEN", temp_username_max_len)
-    patched_log_error = mocker.patch("users.utils.log.error")
+    mocker.patch("mitol.common.utils.user.USERNAME_MAX_LEN", temp_username_max_len)
+    patched_log_error = mocker.patch("mitol.common.utils.user.log.error")
 
     assert usernameify(full_name, email=email) == expected_username
     assert patched_log_error.called == bool(email and not full_name)

--- a/tests/common/utils/test_user.py
+++ b/tests/common/utils/test_user.py
@@ -1,0 +1,51 @@
+"""users utils tests"""
+
+import pytest
+from mitol.common.utils.user import (usernameify, is_duplicate_username_error)
+
+
+@pytest.mark.parametrize(
+    "full_name,email,expected_username",  # noqa: PT006
+    [
+        [" John  Doe ", None, "john-doe"],  # noqa: PT007
+        ["Tabby	Tabberson", None, "tabby-tabberson"],  # noqa: PT007
+        ["Àccèntèd Ñame, Ësq.", None, "àccèntèd-ñame-ësq"],  # noqa: PT007
+        ["-Dashy_St._Underscores-", None, "dashy-st-underscores"],  # noqa: PT007
+        ["Repeated-----Chars___Jr.", None, "repeated-chars-jr"],  # noqa: PT007
+        ["Numbers123 !$!@ McStrange!!##^", None, "numbers-mcstrange"],  # noqa: PT007
+        ["Кирил Френков", None, "кирил-френков"],  # noqa: PT007
+        ["年號", None, "年號"],  # noqa: PT007
+        ["abcdefghijklmnopqrstuvwxyz", None, "abcdefghijklmnopqrst"],  # noqa: PT007
+        ["ai bi cı dI eİ fI", None, "ai-bi-ci-di-ei-fi"],  # noqa: PT007, RUF001
+        ["", "some.email@example.co.uk", "someemail"],  # noqa: PT007
+    ],
+)
+def test_usernameify(mocker, full_name, email, expected_username):
+    """Usernameify should turn a user's name into a username, or use the email if necessary"""
+    # Change the username max length to 20 for test data simplicity's sake
+    temp_username_max_len = 20
+    mocker.patch("users.utils.USERNAME_MAX_LEN", temp_username_max_len)
+    patched_log_error = mocker.patch("users.utils.log.error")
+
+    assert usernameify(full_name, email=email) == expected_username
+    assert patched_log_error.called == bool(email and not full_name)
+
+
+def test_usernameify_fail():
+    """Usernameify should raise an exception if the full name and email both fail to produce a username"""
+    with pytest.raises(ValueError):  # noqa: PT011
+        assert usernameify("!!!", email="???@example.com")
+
+
+@pytest.mark.parametrize(
+    "exception_text,expected_value",  # noqa: PT006
+    [
+        ["DETAILS: (username)=(ABCDEFG) already exists", True],  # noqa: PT007
+        ["DETAILS: (email)=(ABCDEFG) already exists", False],  # noqa: PT007
+    ],
+)
+def test_is_duplicate_username_error(exception_text, expected_value):
+    """
+    is_duplicate_username_error should return True if the exception text provided indicates a duplicate username error
+    """
+    assert is_duplicate_username_error(exception_text) is expected_value

--- a/tests/common/utils/test_user.py
+++ b/tests/common/utils/test_user.py
@@ -1,7 +1,7 @@
 """users utils tests"""
 
 import pytest
-from mitol.common.utils.user import (usernameify, is_duplicate_username_error)
+from mitol.common.utils.user import is_duplicate_username_error, usernameify
 
 
 @pytest.mark.parametrize(
@@ -26,10 +26,13 @@ def test_usernameify(mocker, full_name, email, expected_username):
     """
     # Change the username max length to 20 for test data simplicity's sake
     temp_username_max_len = 20
-    mocker.patch("mitol.common.utils.user.USERNAME_MAX_LEN", temp_username_max_len)
     patched_log_error = mocker.patch("mitol.common.utils.user.log.error")
 
-    assert usernameify(full_name, email=email) == expected_username
+    assert usernameify(
+        full_name,
+        email=email,
+        max_length=temp_username_max_len
+    ) == expected_username
     assert patched_log_error.called == bool(email and not full_name)
 
 

--- a/tests/common/utils/test_user.py
+++ b/tests/common/utils/test_user.py
@@ -21,7 +21,9 @@ from mitol.common.utils.user import (usernameify, is_duplicate_username_error)
     ],
 )
 def test_usernameify(mocker, full_name, email, expected_username):
-    """Usernameify should turn a user's name into a username, or use the email if necessary"""
+    """Usernameify should turn a user's name into a username, or use the email
+    if necessary
+    """
     # Change the username max length to 20 for test data simplicity's sake
     temp_username_max_len = 20
     mocker.patch("mitol.common.utils.user.USERNAME_MAX_LEN", temp_username_max_len)
@@ -32,7 +34,9 @@ def test_usernameify(mocker, full_name, email, expected_username):
 
 
 def test_usernameify_fail():
-    """Usernameify should raise an exception if the full name and email both fail to produce a username"""
+    """Usernameify should raise an exception if the full name and email both
+    fail to produce a username
+    """
     with pytest.raises(ValueError):  # noqa: PT011
         assert usernameify("!!!", email="???@example.com")
 
@@ -46,6 +50,7 @@ def test_usernameify_fail():
 )
 def test_is_duplicate_username_error(exception_text, expected_value):
     """
-    is_duplicate_username_error should return True if the exception text provided indicates a duplicate username error
+    is_duplicate_username_error should return True if the exception text
+    provided indicates a duplicate username error
     """
     assert is_duplicate_username_error(exception_text) is expected_value


### PR DESCRIPTION
### What are the relevant tickets?
[#7460](https://github.com/mitodl/hq/issues/7460)

### Description (What does it do?)
This PR extracts username generation utilities from the xPRO application to the ol-django commons package, making this functionality available for reuse across other Django applications in our ecosystem.

#### Changes Made

Moved username generation utilities from xPRO-specific location to ol-django/commons/utils/user.py
Extracted the following functions:

- usernameify() - Generate usernames from full names with email fallback
- create_user_with_generated_username() - Create users with automatic username collision handling
- _find_available_username() - Handle username conflicts by appending numeric suffixes
- _reformat_for_username() - Clean and format strings for username use
- is_duplicate_username_error() - Detect database integrity errors for username collisions


### How can this be tested?
#### Prerequisites

- xPRO application set up and running locally
- ol-django package installed in the xPRO environment

#### Test Setup

- Install the updated ol-django package: `pip install -e /path/to/ol-django`
- Update the import in [authentication/pipeline/user.py#L87](https://github.com/mitodl/mitxpro/blob/master/authentication/pipeline/user.py#L87):
    ```python
    from mitol.common.utils import usernameify, create_user_with_generated_username
    ```

#### Testing Steps

- Register new users via UI and verify usernames are generated correctly
- Test email fallback when full name is empty or invalid
-  Register multiple users with identical names to test collision handling
- Test OAuth registration flows still work
- Verify existing users can still log in normally
- Confirm username formats follow expected patterns
- Ensure no existing functionality is broken

#### Note for Other Applications
The [create_user_via_email function in xPRO](https://github.com/mitodl/mitxpro/blob/master/authentication/pipeline/user.py#L87) serves as a reference implementation showing how these utilities can be integrated. Other Django applications can follow a similar pattern by importing the two main API functions namely `usernameify` and `create_user_with_generated_username` from the commons package and adapting the integration to their specific user creation workflows.