### PR TITLE
Add option to run sync only for unsynced users

### DIFF
--- a/src/scim/mitol/scim/management/commands/scim_sync.py
+++ b/src/scim/mitol/scim/management/commands/scim_sync.py
@@ -8,11 +8,24 @@ class Command(BaseCommand):
 
     help = "Sync users with SCIM to the remote"
 
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--never-synced-only",
+            type=bool,
+            action="store_true",
+            default=False,
+            help="Only sync users who have never been synced",
+        )
+
     def handle(self, *args, **options):  # noqa: ARG002
         """Sync users with SCIM to the remote"""
         from mitol.scim import tasks
 
-        task = tasks.sync_all_users_to_scim_remote.delay()
+        never_synced_only = options["never-synced-only"]
+
+        task = tasks.sync_all_users_to_scim_remote.delay(
+            never_synced_only=never_synced_only
+        )
 
         task.get()
 

--- a/src/scim/mitol/scim/tasks.py
+++ b/src/scim/mitol/scim/tasks.py
@@ -1,5 +1,7 @@
+import logging
 import celery
 from django.contrib.auth import get_user_model
+from django.db.models import Q
 
 from mitol.common.utils.celery import get_celery_app
 from mitol.common.utils.collections import chunks
@@ -7,6 +9,9 @@ from mitol.scim import api
 
 User = get_user_model()
 app = get_celery_app()
+
+
+log = logging.getLogger()
 
 
 @app.task(acks_late=True)
@@ -17,14 +22,21 @@ def sync_users_to_scim_remote_batch(*, user_ids: list[int]):
 
 
 @app.task(bind=True, acks_late=True)
-def sync_all_users_to_scim_remote(self):
+def sync_all_users_to_scim_remote(self, *, never_synced_only: bool = False):
+    user_q = (
+        User.objects.values_list("id", flat=True).filter(is_active=True).order_by("id")
+    )
+
+    if never_synced_only:
+        user_q = user_q.filter(Q(global_id="") | Q(scim_external_id=None))
+
+    log.info(f"Syncing {user_q.count()} users to SCIM remote")
+
     return self.replace(
         celery.group(
             sync_users_to_scim_remote_batch.si(user_ids=user_ids)
             for user_ids in chunks(
-                User.objects.values_list("id", flat=True)
-                .filter(is_active=True)
-                .order_by("id"),
+                user_q,
                 chunk_size=1000,
             )
         )

--- a/src/scim/mitol/scim/tasks.py
+++ b/src/scim/mitol/scim/tasks.py
@@ -1,4 +1,5 @@
 import logging
+
 import celery
 from django.contrib.auth import get_user_model
 from django.db.models import Q
@@ -30,7 +31,8 @@ def sync_all_users_to_scim_remote(self, *, never_synced_only: bool = False):
     if never_synced_only:
         user_q = user_q.filter(Q(global_id="") | Q(scim_external_id=None))
 
-    log.info(f"Syncing {user_q.count()} users to SCIM remote")
+    msg = f"Syncing {user_q.count()} users to SCIM remote"
+    log.info(msg)
 
     return self.replace(
         celery.group(

--- a/tests/scim/test_tasks.py
+++ b/tests/scim/test_tasks.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import get_user_model
 import pytest
 from mitol.common.factories import UserFactory
 from mitol.common.factories.defaults import ScimUserFactory, SsoUserFactory
@@ -6,9 +7,13 @@ from more_itertools import flatten
 
 pytestmark = pytest.mark.django_db
 
+User = get_user_model()
+
 
 @pytest.mark.parametrize("never_synced_only", [True, False])
 def test_sync_all_users_to_scim_remote(mocker, never_synced_only):
+    print(User.objects.all())
+
     synced_users = ScimUserFactory.create_batch(10)
     unsynced_users = UserFactory.create_batch(10)
     sso_users = SsoUserFactory.create_batch(10)

--- a/tests/scim/test_tasks.py
+++ b/tests/scim/test_tasks.py
@@ -1,0 +1,36 @@
+import pytest
+from mitol.common.factories import UserFactory
+from mitol.common.factories.defaults import ScimUserFactory, SsoUserFactory
+from mitol.scim import tasks
+from more_itertools import flatten
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize("never_synced_only", [True, False])
+def test_sync_all_users_to_scim_remote(mocker, never_synced_only):
+    synced_users = ScimUserFactory.create_batch(10)
+    unsynced_users = UserFactory.create_batch(10)
+    sso_users = SsoUserFactory.create_batch(10)
+
+    expected_users = [
+        *sso_users,
+        *unsynced_users,
+    ]
+
+    if not never_synced_only:
+        expected_users.extend(synced_users)
+
+    mock_replace = mocker.patch(
+        "mitol.scim.tasks.sync_all_users_to_scim_remote.replace", autospec=True
+    )
+
+    tasks.sync_all_users_to_scim_remote(never_synced_only=never_synced_only)
+
+    mock_replace.assert_called_once()
+
+    group = mock_replace.call_args[0][0]
+
+    user_ids = flatten([task.kwargs["user_ids"] for task in group.tasks])
+
+    assert set(user_ids) == {user.id for user in expected_users}

--- a/tests/scim/test_tasks.py
+++ b/tests/scim/test_tasks.py
@@ -1,5 +1,5 @@
-from django.contrib.auth import get_user_model
 import pytest
+from django.contrib.auth import get_user_model
 from mitol.common.factories import UserFactory
 from mitol.common.factories.defaults import ScimUserFactory, SsoUserFactory
 from mitol.scim import tasks
@@ -12,7 +12,7 @@ User = get_user_model()
 
 @pytest.mark.parametrize("never_synced_only", [True, False])
 def test_sync_all_users_to_scim_remote(mocker, never_synced_only):
-    print(User.objects.all())
+    existing_user_ids = {user.id for user in User.objects.all()}
 
     synced_users = ScimUserFactory.create_batch(10)
     unsynced_users = UserFactory.create_batch(10)
@@ -38,4 +38,4 @@ def test_sync_all_users_to_scim_remote(mocker, never_synced_only):
 
     user_ids = flatten([task.kwargs["user_ids"] for task in group.tasks])
 
-    assert set(user_ids) == {user.id for user in expected_users}
+    assert (set(user_ids) - existing_user_ids) == {user.id for user in expected_users}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/7521

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds a `--never-synced-only` flag that only syncs users that don't have `global_id` and/or `scim_external_id`. This will help reduce the number of users the command attempts to sync so we can more easily debug it.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass