### PR TITLE
Remove type= in scim_sync arg setup

### DIFF
--- a/src/scim/changelog.d/20250610_121232_nlevesq_fix_scim_sync_arg.md
+++ b/src/scim/changelog.d/20250610_121232_nlevesq_fix_scim_sync_arg.md
@@ -1,0 +1,42 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Removed errant `type=` argument passed to scim_scim arg setup.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/scim/mitol/scim/management/commands/scim_sync.py
+++ b/src/scim/mitol/scim/management/commands/scim_sync.py
@@ -11,7 +11,6 @@ class Command(BaseCommand):
     def add_arguments(self, parser) -> None:
         parser.add_argument(
             "--never-synced-only",
-            type=bool,
             action="store_true",
             default=False,
             help="Only sync users who have never been synced",

--- a/uv.lock
+++ b/uv.lock
@@ -1706,7 +1706,7 @@ requires-dist = [
 
 [[package]]
 name = "mitol-django-scim"
-version = "2025.5.30.2"
+version = "2025.6.10"
 source = { editable = "src/scim" }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Apparently `type=` raises an error when used with `action="store_true"`.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You can run `uv run ./testapp/manage.py scim_sync --help` and it won't fail.