### PR TITLE
Umar/7650 templates directory not included in wheel packages for mail module

### DIFF
--- a/src/mail/changelog.d/20250624_024151_umar.hassan8_7650_templates_directory_not_included_in_wheel_packages_for_mail_module.md
+++ b/src/mail/changelog.d/20250624_024151_umar.hassan8_7650_templates_directory_not_included_in_wheel_packages_for_mail_module.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- Added templates directory in mail app build
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/mail/pyproject.toml
+++ b/src/mail/pyproject.toml
@@ -37,5 +37,5 @@ include = ["CHANGELOG.md", "README.md", "py.typed", "**/*.py", "**/templates/**/
 exclude = ["BUILD", "pyproject.toml"]
 
 [tool.hatch.build.targets.wheel]
-include = ["CHANGELOG.md", "README.md", "py.typed", "**/*.py"]
+include = ["CHANGELOG.md", "README.md", "py.typed", "**/*.py", "**/templates/**/*"]
 exclude = ["BUILD", "pyproject.toml"]


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7650

### Description (What does it do?)
This PR fixes a packaging issue where the `mitol/mail/templates` directory was being excluded from wheel packages when building with `uv`. The templates directory contains essential Django HTML templates that are required at runtime.

### How can this be tested?
1. **Before the fix - Reproduce the issue:**
   ```bash
   cd src/mail/
   uv build
   cd ../..

   # Extract the wheel and verify templates are missing
   unzip -l dist/mitol_django_mail-*.whl | grep templates

   # It shouldn't show anything
   ```
2. After the fix, verify templates are included:
   ```
   cd src/mail/
   uv build
   cd ../..

   # Extract the wheel and verify templates are now included
   unzip -l dist/mitol_django_mail-*.whl | grep templates

   # Should show files like:
   # mitol/mail/templates/mail/email_base.html
   # mitol/mail/templates/mail/email_debugger.html
   # mitol/mail/templates/mail/partials/...
   ```
3. Test package installation:
   ```
   pip install dist/mitol_django_mail-*.whl
   python -c "import mitol.mail; print('Module imported')"
   ```