### PR TITLE
tests: add more username tests

### DIFF
--- a/src/common/mitol/common/utils/user.py
+++ b/src/common/mitol/common/utils/user.py
@@ -116,7 +116,6 @@ def _find_available_username(
         max_suffix = max_or_none(
             int(re.search(r"\d+$", username).group())
             for username in existing_usernames
-            if re.search(r"\d+$", username) is not None
         )
         if max_suffix is None:
             return "".join([username_base, str(current_min_suffix)])

--- a/src/common/mitol/common/utils/user.py
+++ b/src/common/mitol/common/utils/user.py
@@ -114,8 +114,7 @@ def _find_available_username(
             username_field, flat=True
         )
         max_suffix = max_or_none(
-            int(re.search(r"\d+$", username).group())
-            for username in existing_usernames
+            int(re.search(r"\d+$", username).group()) for username in existing_usernames
         )
         if max_suffix is None:
             return "".join([username_base, str(current_min_suffix)])

--- a/src/common/mitol/common/utils/user.py
+++ b/src/common/mitol/common/utils/user.py
@@ -114,7 +114,9 @@ def _find_available_username(
             username_field, flat=True
         )
         max_suffix = max_or_none(
-            int(re.search(r"\d+$", username).group()) for username in existing_usernames
+            int(re.search(r"\d+$", username).group())
+            for username in existing_usernames
+            if re.search(r"\d+$", username) is not None
         )
         if max_suffix is None:
             return "".join([username_base, str(current_min_suffix)])

--- a/tests/common/utils/test_helpers.py
+++ b/tests/common/utils/test_helpers.py
@@ -2,11 +2,14 @@
 
 from mitol.common.utils.helpers import max_or_none
 
+MAX_TEST_VALUE = 5
+
 
 def test_max_or_none():
     """
-    Assert that max_or_none returns the max of some iterable, or None if the iterable has no items
+    Assert that max_or_none returns the max of some iterable,
+    or None if the iterable has no items
     """
-    assert max_or_none(i for i in [5, 4, 3, 2, 1]) == 5
-    assert max_or_none([1, 3, 5, 4, 2]) == 5
+    assert max_or_none(i for i in [5, 4, 3, 2, 1]) == MAX_TEST_VALUE
+    assert max_or_none([1, 3, 5, 4, 2]) == MAX_TEST_VALUE
     assert max_or_none([]) is None

--- a/tests/common/utils/test_helpers.py
+++ b/tests/common/utils/test_helpers.py
@@ -1,0 +1,12 @@
+"""Utils tests"""
+
+from mitol.common.utils.helpers import max_or_none
+
+
+def test_max_or_none():
+    """
+    Assert that max_or_none returns the max of some iterable, or None if the iterable has no items
+    """
+    assert max_or_none(i for i in [5, 4, 3, 2, 1]) == 5
+    assert max_or_none([1, 3, 5, 4, 2]) == 5
+    assert max_or_none([]) is None

--- a/tests/common/utils/test_user.py
+++ b/tests/common/utils/test_user.py
@@ -1,7 +1,9 @@
 """users utils tests"""
 
 import pytest
-from mitol.common.utils.user import is_duplicate_username_error, usernameify
+from mitol.common.utils.user import is_duplicate_username_error, usernameify, create_user_with_generated_username, _find_available_username
+from unittest.mock import Mock, patch
+from django.db import IntegrityError
 
 
 @pytest.mark.parametrize(
@@ -56,3 +58,173 @@ def test_is_duplicate_username_error(exception_text, expected_value):
     provided indicates a duplicate username error
     """
     assert is_duplicate_username_error(exception_text) is expected_value
+
+
+class DummyIntegrityError(Exception):
+    """Dummy exception to simulate IntegrityError for username collisions in tests."""
+    pass
+
+
+@pytest.fixture
+def fake_user():
+    return Mock(username="testuser")
+
+
+@patch("mitol.common.utils.user._find_available_username")
+def test_create_user_first_try_success(mock_find_username, fake_user):
+    """
+    Test that create_user_with_generated_username succeeds on the first try if there is no collision.
+    """
+    serializer = Mock()
+    serializer.save.return_value = fake_user
+    result = create_user_with_generated_username(
+        serializer=serializer,
+        initial_username="testuser",
+        username_field="username",
+        max_length=30,
+        model=None,
+        attempts_limit=3
+    )
+    assert result == fake_user
+    serializer.save.assert_called_once_with(username="testuser")
+    mock_find_username.assert_not_called()
+
+
+@patch("mitol.common.utils.user._find_available_username")
+def test_create_user_with_collision_and_retry(mock_find_username, fake_user):
+    """
+    Test that create_user_with_generated_username retries on username collision and succeeds on retry.
+    """
+    serializer = Mock()
+    duplicate_error = IntegrityError("duplicate key value violates unique constraint")
+    serializer.save.side_effect = [
+        duplicate_error,
+        fake_user,
+    ]
+    mock_find_username.return_value = "testuser1"
+    with patch("mitol.common.utils.user.is_duplicate_username_error", return_value=True):
+        result = create_user_with_generated_username(
+            serializer=serializer,
+            initial_username="testuser",
+            username_field="username",
+            max_length=30,
+            model=None,
+            attempts_limit=3
+        )
+    assert result == fake_user
+    assert serializer.save.call_count == 2
+    assert mock_find_username.call_count == 1
+    serializer.save.assert_called_with(username="testuser1")
+
+
+@patch("mitol.common.utils.user._find_available_username")
+def test_create_user_fails_after_max_attempts(mock_find_username):
+    """
+    Test that create_user_with_generated_username returns None after exhausting all attempts due to collisions.
+    """
+    serializer = Mock()
+    serializer.save.side_effect = IntegrityError("duplicate")
+    mock_find_username.side_effect = lambda *args, **kwargs: "newusername"
+    with patch("mitol.common.utils.user.is_duplicate_username_error", return_value=True):
+        result = create_user_with_generated_username(
+            serializer=serializer,
+            initial_username="testuser",
+            username_field="username",
+            max_length=30,
+            model=None,
+            attempts_limit=2
+        )
+    assert result is None
+    assert serializer.save.call_count == 2
+
+
+@patch("mitol.common.utils.user._find_available_username")
+def test_create_user_non_username_error_raises(mock_find_username):
+    """
+    Test that create_user_with_generated_username does not retry and raises if the error is not a username collision.
+    """
+    serializer = Mock()
+    serializer.save.side_effect = IntegrityError("some other db error")
+    with patch("mitol.common.utils.user.is_duplicate_username_error", return_value=False):
+        with pytest.raises(IntegrityError, match="some other db error"):
+            create_user_with_generated_username(
+                serializer=serializer,
+                initial_username="testuser",
+                username_field="username",
+                max_length=30,
+                model=None,
+                attempts_limit=1
+            )
+
+
+@patch("mitol.common.utils.user._find_available_username")
+def test_create_user_initial_username_too_short(mock_find_username, fake_user):
+    """
+    Test that create_user_with_generated_username appends '11' if the initial username is too short.
+    """
+    serializer = Mock()
+    serializer.save.return_value = fake_user
+    result = create_user_with_generated_username(
+        serializer=serializer,
+        initial_username="a",
+        username_field="username",
+        max_length=30,
+        model=None,
+        attempts_limit=3
+    )
+    assert result == fake_user
+    serializer.save.assert_called_once_with(username="a11")
+    mock_find_username.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "username_base,existing_usernames,expected",
+    [
+        ("someuser", ["someuser"], "someuser1"),
+        ("someuser", ["someuser", "someuser1", "someuser2", "someuser3", "someuser4", "someuser5"], "someuser6"),
+        ("abcdefghij", ["abcdefghij"] + [f"abcdefghij{i}" for i in range(1, 11)], "abcdefgh11"),
+        ("abcdefghi", ["abcdefghi"] + [f"abcdefghi{i}" for i in range(1, 100)], "abcdefg100"),
+    ],
+)
+def test_find_available_username(username_base, existing_usernames, expected):
+    """
+    Test that _find_available_username returns the correct next available username given existing usernames.
+    """
+    mock_model = Mock()
+    mock_qs = Mock()
+    mock_qs.values_list.return_value = existing_usernames
+    mock_model.objects.filter.return_value = mock_qs
+
+    result = _find_available_username(
+        initial_username_base=username_base,
+        model=mock_model,
+        username_field="username",
+        max_length=10,
+    )
+    assert result == expected
+
+
+def test_full_username_creation():
+    """
+    Ensure that usernameify respects max length and that _find_available_username
+    generates a suffixed username that also respects max length.
+    """
+    expected_username_max = 30
+    user_full_name = "Longerton McLongernamenbergenstein"
+    generated_username = usernameify(user_full_name, max_length=expected_username_max)
+    assert len(generated_username) == expected_username_max
+
+    mock_model = Mock()
+    mock_qs = Mock()
+
+    mock_qs.values_list.return_value = [generated_username]
+    mock_model.objects.filter.return_value = mock_qs
+
+    available_username = _find_available_username(
+        initial_username_base=generated_username,
+        model=mock_model,
+        username_field="username",
+        max_length=expected_username_max,
+    )
+    assert available_username == f"{generated_username[:-1]}1"
+    assert len(available_username) == expected_username_max

--- a/tests/common/utils/test_user.py
+++ b/tests/common/utils/test_user.py
@@ -1,9 +1,18 @@
 """users utils tests"""
 
-import pytest
-from mitol.common.utils.user import is_duplicate_username_error, usernameify, create_user_with_generated_username, _find_available_username
 from unittest.mock import Mock, patch
+
+import pytest
 from django.db import IntegrityError
+from mitol.common.utils.user import (
+    _find_available_username,
+    create_user_with_generated_username,
+    is_duplicate_username_error,
+    usernameify,
+)
+
+EXPECTED_RETRY_COUNT = 2
+MAX_ATTEMPTS_LIMIT = 2
 
 
 @pytest.mark.parametrize(
@@ -60,20 +69,20 @@ def test_is_duplicate_username_error(exception_text, expected_value):
     assert is_duplicate_username_error(exception_text) is expected_value
 
 
-class DummyIntegrityError(Exception):
-    """Dummy exception to simulate IntegrityError for username collisions in tests."""
-    pass
-
-
 @pytest.fixture
 def fake_user():
+    """
+    Fixture that returns a mock user object with a username attribute.
+    Used for testing username generation and collision logic.
+    """
     return Mock(username="testuser")
 
 
 @patch("mitol.common.utils.user._find_available_username")
 def test_create_user_first_try_success(mock_find_username, fake_user):
     """
-    Test that create_user_with_generated_username succeeds on the first try if there is no collision.
+    Test that create_user_with_generated_username succeeds on the first try
+    if there is no collision.
     """
     serializer = Mock()
     serializer.save.return_value = fake_user
@@ -83,7 +92,7 @@ def test_create_user_first_try_success(mock_find_username, fake_user):
         username_field="username",
         max_length=30,
         model=None,
-        attempts_limit=3
+        attempts_limit=3,
     )
     assert result == fake_user
     serializer.save.assert_called_once_with(username="testuser")
@@ -93,26 +102,32 @@ def test_create_user_first_try_success(mock_find_username, fake_user):
 @patch("mitol.common.utils.user._find_available_username")
 def test_create_user_with_collision_and_retry(mock_find_username, fake_user):
     """
-    Test that create_user_with_generated_username retries on username collision and succeeds on retry.
+    Test that create_user_with_generated_username retries on username
+    collision and succeeds on retry.
     """
     serializer = Mock()
-    duplicate_error = IntegrityError("duplicate key value violates unique constraint")
+    duplicate_error = IntegrityError(
+        "duplicate key value violates unique constraint"
+    )
     serializer.save.side_effect = [
         duplicate_error,
         fake_user,
     ]
     mock_find_username.return_value = "testuser1"
-    with patch("mitol.common.utils.user.is_duplicate_username_error", return_value=True):
+    with patch(
+        "mitol.common.utils.user.is_duplicate_username_error",
+        return_value=True
+    ):
         result = create_user_with_generated_username(
             serializer=serializer,
             initial_username="testuser",
             username_field="username",
             max_length=30,
             model=None,
-            attempts_limit=3
+            attempts_limit=3,
         )
     assert result == fake_user
-    assert serializer.save.call_count == 2
+    assert serializer.save.call_count == EXPECTED_RETRY_COUNT
     assert mock_find_username.call_count == 1
     serializer.save.assert_called_with(username="testuser1")
 
@@ -120,47 +135,55 @@ def test_create_user_with_collision_and_retry(mock_find_username, fake_user):
 @patch("mitol.common.utils.user._find_available_username")
 def test_create_user_fails_after_max_attempts(mock_find_username):
     """
-    Test that create_user_with_generated_username returns None after exhausting all attempts due to collisions.
+    Test that create_user_with_generated_username returns None after
+    exhausting all attempts due to collisions.
     """
     serializer = Mock()
     serializer.save.side_effect = IntegrityError("duplicate")
-    mock_find_username.side_effect = lambda *args, **kwargs: "newusername"
-    with patch("mitol.common.utils.user.is_duplicate_username_error", return_value=True):
+    mock_find_username.side_effect = lambda *_args, **_kwargs: "newusername"
+    with patch(
+        "mitol.common.utils.user.is_duplicate_username_error",
+        return_value=True
+    ):
         result = create_user_with_generated_username(
             serializer=serializer,
             initial_username="testuser",
             username_field="username",
             max_length=30,
             model=None,
-            attempts_limit=2
+            attempts_limit=MAX_ATTEMPTS_LIMIT,
         )
     assert result is None
-    assert serializer.save.call_count == 2
+    assert serializer.save.call_count == MAX_ATTEMPTS_LIMIT
 
 
 @patch("mitol.common.utils.user._find_available_username")
-def test_create_user_non_username_error_raises(mock_find_username):
+def test_create_user_non_username_error_raises():
     """
-    Test that create_user_with_generated_username does not retry and raises if the error is not a username collision.
+    Test that create_user_with_generated_username does not retry and raises
+    if the error is not a username collision.
     """
     serializer = Mock()
     serializer.save.side_effect = IntegrityError("some other db error")
-    with patch("mitol.common.utils.user.is_duplicate_username_error", return_value=False):
-        with pytest.raises(IntegrityError, match="some other db error"):
-            create_user_with_generated_username(
-                serializer=serializer,
-                initial_username="testuser",
-                username_field="username",
-                max_length=30,
-                model=None,
-                attempts_limit=1
-            )
+    with patch(
+        "mitol.common.utils.user.is_duplicate_username_error",
+        return_value=False
+    ), pytest.raises(IntegrityError, match="some other db error"):
+        create_user_with_generated_username(
+            serializer=serializer,
+            initial_username="testuser",
+            username_field="username",
+            max_length=30,
+            model=None,
+            attempts_limit=1,
+        )
 
 
 @patch("mitol.common.utils.user._find_available_username")
 def test_create_user_initial_username_too_short(mock_find_username, fake_user):
     """
-    Test that create_user_with_generated_username appends '11' if the initial username is too short.
+    Test that create_user_with_generated_username appends '11'
+    if the initial username is too short.
     """
     serializer = Mock()
     serializer.save.return_value = fake_user
@@ -170,7 +193,7 @@ def test_create_user_initial_username_too_short(mock_find_username, fake_user):
         username_field="username",
         max_length=30,
         model=None,
-        attempts_limit=3
+        attempts_limit=3,
     )
     assert result == fake_user
     serializer.save.assert_called_once_with(username="a11")
@@ -178,17 +201,37 @@ def test_create_user_initial_username_too_short(mock_find_username, fake_user):
 
 
 @pytest.mark.parametrize(
-    "username_base,existing_usernames,expected",
+    ("username_base", "existing_usernames", "expected"),
     [
         ("someuser", ["someuser"], "someuser1"),
-        ("someuser", ["someuser", "someuser1", "someuser2", "someuser3", "someuser4", "someuser5"], "someuser6"),
-        ("abcdefghij", ["abcdefghij"] + [f"abcdefghij{i}" for i in range(1, 11)], "abcdefgh11"),
-        ("abcdefghi", ["abcdefghi"] + [f"abcdefghi{i}" for i in range(1, 100)], "abcdefg100"),
+        (
+            "someuser",
+            [
+                "someuser",
+                "someuser1",
+                "someuser2",
+                "someuser3",
+                "someuser4",
+                "someuser5",
+            ],
+            "someuser6",
+        ),
+        (
+            "abcdefghij",
+            ["abcdefghij"] + [f"abcdefghij{i}" for i in range(1, 11)],
+            "abcdefgh11",
+        ),
+        (
+            "abcdefghi",
+            ["abcdefghi"] + [f"abcdefghi{i}" for i in range(1, 100)],
+            "abcdefg100",
+        ),
     ],
 )
 def test_find_available_username(username_base, existing_usernames, expected):
     """
-    Test that _find_available_username returns the correct next available username given existing usernames.
+    Test that _find_available_username returns the correct
+    next available username given existing usernames.
     """
     mock_model = Mock()
     mock_qs = Mock()
@@ -206,12 +249,15 @@ def test_find_available_username(username_base, existing_usernames, expected):
 
 def test_full_username_creation():
     """
-    Ensure that usernameify respects max length and that _find_available_username
-    generates a suffixed username that also respects max length.
+    Ensure that usernameify respects max length and
+    that _find_available_username generates a suffixed username that
+    also respects max length.
     """
     expected_username_max = 30
     user_full_name = "Longerton McLongernamenbergenstein"
-    generated_username = usernameify(user_full_name, max_length=expected_username_max)
+    generated_username = usernameify(
+        user_full_name, max_length=expected_username_max
+    )
     assert len(generated_username) == expected_username_max
 
     mock_model = Mock()

--- a/tests/common/utils/test_user.py
+++ b/tests/common/utils/test_user.py
@@ -3,14 +3,13 @@
 from unittest.mock import Mock, patch
 
 import pytest
-import re
 from django.db import IntegrityError
 from mitol.common.utils.user import (
+    USERNAME_COLLISION_ATTEMPTS,
     _find_available_username,
     create_user_with_generated_username,
     is_duplicate_username_error,
     usernameify,
-    USERNAME_COLLISION_ATTEMPTS,
 )
 
 EXPECTED_RETRY_COUNT = 2
@@ -107,17 +106,14 @@ def test_create_user_with_collision_and_retry(mock_find_username, fake_user):
     collision and succeeds on retry.
     """
     serializer = Mock()
-    duplicate_error = IntegrityError(
-        "duplicate key value violates unique constraint"
-    )
+    duplicate_error = IntegrityError("duplicate key value violates unique constraint")
     serializer.save.side_effect = [
         duplicate_error,
         fake_user,
     ]
     mock_find_username.return_value = "testuser1"
     with patch(
-        "mitol.common.utils.user.is_duplicate_username_error",
-        return_value=True
+        "mitol.common.utils.user.is_duplicate_username_error", return_value=True
     ):
         result = create_user_with_generated_username(
             serializer=serializer,
@@ -143,8 +139,7 @@ def test_create_user_fails_after_max_attempts(mock_find_username):
     serializer.save.side_effect = IntegrityError("duplicate")
     mock_find_username.return_value = "newusername"
     with patch(
-        "mitol.common.utils.user.is_duplicate_username_error",
-        return_value=True
+        "mitol.common.utils.user.is_duplicate_username_error", return_value=True
     ):
         result = create_user_with_generated_username(
             serializer=serializer,
@@ -165,10 +160,12 @@ def test_create_user_raises_on_unknown_integrity_error():
     """
     serializer = Mock()
     serializer.save.side_effect = IntegrityError("some other db error")
-    with patch(
-        "mitol.common.utils.user.is_duplicate_username_error",
-        return_value=False
-    ), pytest.raises(IntegrityError, match="some other db error"):
+    with (
+        patch(
+            "mitol.common.utils.user.is_duplicate_username_error", return_value=False
+        ),
+        pytest.raises(IntegrityError, match="some other db error"),
+    ):
         create_user_with_generated_username(
             serializer=serializer,
             initial_username="testuser",
@@ -248,9 +245,7 @@ def test_full_username_creation():
     """
     expected_username_max = 30
     user_full_name = "Longerton McLongernamenbergenstein"
-    generated_username = usernameify(
-        user_full_name, max_length=expected_username_max
-    )
+    generated_username = usernameify(user_full_name, max_length=expected_username_max)
     assert len(generated_username) == expected_username_max
 
     mock_model = Mock()

--- a/tests/common/utils/test_user.py
+++ b/tests/common/utils/test_user.py
@@ -159,7 +159,7 @@ def test_create_user_fails_after_max_attempts(mock_find_username):
 
 
 @patch("mitol.common.utils.user._find_available_username")
-def test_create_user_non_username_error_raises(mock_find_username):
+def test_create_user_non_username_error_raises(mock_find_username):  # noqa: ARG001
     """
     Test that create_user_with_generated_username does not retry and raises
     if the error is not a username collision.


### PR DESCRIPTION
### What are the relevant tickets?
[#7460](https://github.com/mitodl/hq/issues/7460)

### Description (What does it do?)

This PR migrates and generalizes all core tests for username generation and collision handling from MITxPRO to ol-django, ensuring that the shared username logic is independently tested.

### How can this be tested?

- All tests added should be generic and not depend on any app-specific models or serializers.
- Tests should be passing
