### PR TITLE
Handle non-str values in request.META

### DIFF
--- a/src/scim/changelog.d/20250721_154048_nlevesq_fix_for_bad_meta_kvs.md
+++ b/src/scim/changelog.d/20250721_154048_nlevesq_fix_for_bad_meta_kvs.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- Added filtering to not deepcopy non-str values on the header dict `request.META`.
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/scim/mitol/scim/requests.py
+++ b/src/scim/mitol/scim/requests.py
@@ -37,7 +37,7 @@ class InMemoryHttpRequest(HttpRequest):
             {
                 key: value
                 for key, value in meta.items()
-                if not key.startswith(("wsgi", "uwsgi"))
+                if isinstance(value, str) and not key.startswith(("wsgi", "uwsgi"))
             }
         )
         self.path = path

--- a/tests/scim/test_requests.py
+++ b/tests/scim/test_requests.py
@@ -1,0 +1,13 @@
+from mitol.scim.requests import InMemoryHttpRequest
+
+
+def test_from_request(rf):
+    """Should be able to make an in-memory http request"""
+    request = rf.get("/")
+    request.META["not-str-value"] = object()
+
+    req = InMemoryHttpRequest.from_request(
+        request, request.path, request.method, "data"
+    )
+
+    assert "not-str-value" not in req.META


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/mitxonline/issues/2812

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds code to exclude non-str values when our in-memory http request deepcopies the `request.META` object. It should not be the case that these values exist there as it's supposed to be only HTTP headers, but some packages/middleware seem to abuse the mechanism to suff various objects in there that break `deepcopy` as they can't be pickled.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass.