### PR TITLE
Return lowercase email on SCIM APIs

### DIFF
--- a/src/scim/changelog.d/20250728_103424_nlevesq_fix_email_scim_lowercase.md
+++ b/src/scim/changelog.d/20250728_103424_nlevesq_fix_email_scim_lowercase.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- Updated SCIM user serialization to return lowercase email
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/scim/mitol/scim/adapters.py
+++ b/src/scim/mitol/scim/adapters.py
@@ -70,7 +70,7 @@ class UserAdapter(SCIMUser):
         """
         Return the email of the user per the SCIM spec.
         """
-        return [{"value": self.obj.email, "primary": True}]
+        return [{"value": self.obj.email.lower(), "primary": True}]
 
     @property
     def display_name(self):

--- a/tests/scim/test_views.py
+++ b/tests/scim/test_views.py
@@ -490,7 +490,7 @@ def test_user_search(large_user_set, scim_client, sort_by, sort_order, count):
                     "active": user.is_active,
                     "userName": user.username,
                     "displayName": f"{user.first_name} {user.last_name}",
-                    "emails": [{"value": user.email, "primary": True}],
+                    "emails": [{"value": user.email.lower(), "primary": True}],
                     "externalId": None,
                     "name": {
                         "givenName": user.first_name,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/7912

### Description (What does it do?)
<!--- Describe your changes in detail -->
Returns the lowercase email because scim-for-keycloak is making case sensitive comparisons on its end and all keycloak emails will be lowercase.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass.