### PR TITLE
Batch up SCIM search requests to avoid timeout

### DIFF
--- a/src/scim/changelog.d/20250729_113307_nlevesq_search_batch_size.md
+++ b/src/scim/changelog.d/20250729_113307_nlevesq_search_batch_size.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- Batched up search requests to avoid timeouts (pagination wasn't enough).
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/scim/mitol/scim/api.py
+++ b/src/scim/mitol/scim/api.py
@@ -94,6 +94,13 @@ def sync_users_to_scim_remote(users: list["User"]):
 def _user_search_by_email(
     session: OAuth2Session, users: list["User"]
 ) -> StateOrOperationGenerator:
+    for users_batch in chunked(users, settings.MITOL_SCIM_KEYCLOAK_SEARCH_BATCH_SIZE):
+        yield from _user_search_by_email_batch(session, users_batch)
+
+
+def _user_search_by_email_batch(
+    session: OAuth2Session, users: list["User"]
+) -> StateOrOperationGenerator:
     """Perform a search for a set of users by email"""
     users_by_email = {user.email.lower(): user for user in users}
 

--- a/src/scim/mitol/scim/settings/scim.py
+++ b/src/scim/mitol/scim/settings/scim.py
@@ -10,6 +10,11 @@ MITOL_SCIM_KEYCLOAK_BATCH_SIZE = get_int(
     default=250,
     description="Number of operations to send in a single batch request",
 )
+MITOL_SCIM_KEYCLOAK_SEARCH_BATCH_SIZE = get_int(
+    name="MITOL_SCIM_KEYCLOAK_SEARCH_BATCH_SIZE",
+    default=100,
+    description="Number of operations to send in a single search request",
+)
 
 MITOL_SCIM_KEYCLOAK_BULK_OPERATIONS_COUNT = get_int(
     name="MITOL_SCIM_KEYCLOAK_BULK_OPERATIONS_COUNT",

--- a/uv.lock
+++ b/uv.lock
@@ -1728,7 +1728,7 @@ requires-dist = [
 
 [[package]]
 name = "mitol-django-scim"
-version = "2025.7.25"
+version = "2025.7.28"
 source = { editable = "src/scim" }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/mitxonline/issues/2840

### Description (What does it do?)
<!--- Describe your changes in detail -->
This batches up the scim search requests when performing a sync to avoid a timeout caused from the scim-for-keycloak plugin not being able to have larger search requests.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass.