### PR TITLE
Gateway middleware only update if user is changing

### DIFF
--- a/src/apigateway/mitol/apigateway/backends.py
+++ b/src/apigateway/mitol/apigateway/backends.py
@@ -32,6 +32,12 @@ class RemoteUserCustomFieldBackend(RemoteUserBackend):
         user = None
         username = self.clean_username(remote_user)
 
+        # if the current user and the user from the backend match
+        # just return that user and do no further queries or configuration
+        if getattr(request.user, self.lookup_field, None) == username:
+            user = request.user
+            return user if self.user_can_authenticate(user) else None
+
         if self.create_unknown_user:
             user, created = User.objects.get_or_create(**{self.lookup_field: username})
         else:
@@ -47,6 +53,12 @@ class RemoteUserCustomFieldBackend(RemoteUserBackend):
         created = False
         user = None
         username = self.clean_username(remote_user)
+
+        # if the current user and the user from the backend match
+        # just return that user and do no further queries or configuration
+        if getattr(request.user, self.lookup_field, None) == username:
+            user = request.user
+            return user if self.user_can_authenticate(user) else None
 
         if self.create_unknown_user:
             user, created = await User.objects.aget_or_create(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This updates the middleware implementation to skip the db queries if the current user matches the user on the apisix headers. The means in practice we will only update the user on the first request to the app, which will end up being the `/login` route typically (so fortunately no lingering thundering herd issue here).

This should **greatly** reduce the amount of load on the database constantly having to rewrite the user record.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass