### PR TITLE
fix: handle nonetype on existing suffix

### DIFF
--- a/src/common/changelog.d/20250819_163705_areebsajjad21_fix_nonetype_handling.md
+++ b/src/common/changelog.d/20250819_163705_areebsajjad21_fix_nonetype_handling.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Improved username collision detection regex to be more precise and avoid false matches
+- Added proper error handling for username suffix extraction in `_find_available_username`
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/common/mitol/common/utils/user.py
+++ b/src/common/mitol/common/utils/user.py
@@ -113,9 +113,18 @@ def _find_available_username(  # noqa: RET503
         existing_usernames = model.objects.filter(**filter_kwargs).values_list(
             username_field, flat=True
         )
-        max_suffix = max_or_none(
-            int(re.search(r"\d+$", username).group()) for username in existing_usernames
-        )
+
+        suffixes = []
+        for username in existing_usernames:
+            match = re.search(r"\d+$", username)
+            if match is not None:
+                try:
+                    suffixes.append(int(match.group()))
+                except (ValueError, AttributeError):
+                    continue
+
+        max_suffix = max_or_none(suffixes) if suffixes else None
+
         if max_suffix is None:
             return "".join([username_base, str(current_min_suffix)])
         else:

--- a/src/common/mitol/common/utils/user.py
+++ b/src/common/mitol/common/utils/user.py
@@ -109,7 +109,7 @@ def _find_available_username(  # noqa: RET503
         ]
         # Find usernames that match the username base and have a numerical
         # suffix, then find the max suffix
-        filter_kwargs = {f"{username_field}__regex": rf"{username_base}[0-9]+"}
+        filter_kwargs = {f"{username_field}__regex": rf"^{username_base}\d+$"}
         existing_usernames = model.objects.filter(**filter_kwargs).values_list(
             username_field, flat=True
         )

--- a/tests/common/utils/test_user.py
+++ b/tests/common/utils/test_user.py
@@ -223,7 +223,7 @@ def test_create_user_initial_username_too_short(mock_find_username, fake_user):
         (
             "someuser",
             ["someuser1", "someuser2dy", "someuser5"],
-            "ayush6",
+            "someuser6",
         ),
     ],
 )

--- a/tests/common/utils/test_user.py
+++ b/tests/common/utils/test_user.py
@@ -215,6 +215,16 @@ def test_create_user_initial_username_too_short(mock_find_username, fake_user):
             ["abcdefgh97", "abcdefgh98", "abcdefgh99"],
             "abcdefg100",
         ),
+        (
+            "someuser",
+            ["someuser2dy"],
+            "someuser1",
+        ),
+        (
+            "someuser",
+            ["someuser1", "someuser2dy", "someuser5"],
+            "ayush6",
+        ),
     ],
 )
 def test_find_available_username(username_base, existing_usernames, expected):


### PR DESCRIPTION
### What are the relevant tickets?
https://mit-office-of-digital-learning.sentry.io/issues/6791771341/?alert_rule_id=14636035&alert_type=issue&notification_uuid=5f75f059-5cd9-4ad6-bb2e-7c151efcd66b&project=5864687&referrer=slack

### Description (What does it do?)
The `_find_available_username` function was crashing with `NoneType` object has no attribute 'group' when encountering usernames that don't end with digits (e.g., "testuser2dy"). This occurred because `re.search(r"\d+$", username)` returns None for usernames not ending with digits, and calling `.group()` on None causes an `AttributeError`.

This PR modifies the function to safely filter usernames before processing: - Added a check to ensure re.search() returns a match before calling .group() - Wrapped the int() conversion in a try-catch to handle unexpected values - Only process usernames that actually end with digits

### How can this be tested?

1. Install the branch locally on MITxOnline setup
2. Create a user with edx_username that doesn't end with digits (e.g., "testuser2dy")
3. Try to create another user with base username "testuser"
4. Verify the function returns "testuser1" instead of crashing
