### PR TITLE
fix: basic API create parameter name

### DIFF
--- a/src/hubspot_api/changelog.d/20250930_152628_areeb.sajjad_8295_basicapi_create_parameter_fix.md
+++ b/src/hubspot_api/changelog.d/20250930_152628_areeb.sajjad_8295_basicapi_create_parameter_fix.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+
+### Fixed
+
+- Hubspot Basic API create paramter name
+
+
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/hubspot_api/mitol/hubspot_api/api.py
+++ b/src/hubspot_api/mitol/hubspot_api/api.py
@@ -260,8 +260,8 @@ def handle_create_api_error(  # noqa: C901, PLR0913
                 )
             elif retry_create:
                 return HubspotApi().crm.objects.basic_api.create(
-                    simple_public_object_input=body,
                     object_type=hubspot_type,
+                    simple_public_object_input_for_create=body,
                 )
     # This was some other kind of error so raise it
     raise error
@@ -298,7 +298,8 @@ def upsert_object_request(
     else:
         try:
             result = api.create(
-                simple_public_object_input=body, object_type=hubspot_type
+                object_type=hubspot_type,
+                simple_public_object_input_for_create=body,
             )
         except ApiException as err:
             result = handle_create_api_error(


### PR DESCRIPTION
### What are the relevant tickets?
[#8295](https://github.com/mitodl/hq/issues/8295)

### Description (What does it do?)
HubSpot’s Python client changed the [BasicApi.create](https://github.com/HubSpot/hubspot-api-python/blob/master/hubspot/crm/objects/api/basic_api.py#L166) signature to require `simple_public_object_input_for_create`. This caused user syncs to fail during registration/profile update in MITxOnline with `BasicApi.create() missing 1 required positional argument: 'simple_public_object_input_for_create'`. 

This PR updates ol-django/src/hubspot_api/mitol/hubspot_api/api.py to use the correct v12 create call  so single-object contact syncs succeed.

### How can this be tested?
1. Install this branch into your local MITxOnline setup (use uv build to generate a new ol-django-hubspot-api pacakge)
2. User registration flow (single create path):
- Register a new user via the app.
- Verify no error in worker logs.
- Confirm the user appears in HubSpot Contacts with expected properties.
- Confirm users_user.hubspot_sync_datetime populated.
3. Profile update flow (single update path):
- Log in as an existing user.
- Edit profile and save
- Verify no error in logs and updated fields are reflected in HubSpot.


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
