### PR TITLE
Remove the `next` cookie from apigateway

### DIFF
--- a/src/apigateway/changelog.d/20251022_132511_nlevesq.md
+++ b/src/apigateway/changelog.d/20251022_132511_nlevesq.md
@@ -1,0 +1,41 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Removed
+
+- Removed support for the `next` url cookie as the url parameter works and doesn't cause rogue redirects like the cookie can.
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/apigateway/mitol/apigateway/middleware.py
+++ b/src/apigateway/mitol/apigateway/middleware.py
@@ -35,22 +35,7 @@ class ApisixUserMiddleware(RemoteUserMiddleware):
 
         super().process_request(request)
 
-        response = self.get_response(request)
-
-        next_param = request.GET.get("next", None) if request.GET else None
-        if next_param:
-            log.debug(
-                "ApisixUserMiddleware.process_request: Setting next cookie to %s",
-                next_param,
-            )
-            response.set_cookie("next", next_param, max_age=30, secure=False)
-
-        log.debug(
-            "ApisixUserMiddleware.process_request: Next cookie is %s",
-            response.cookies.get("next"),
-        )
-
-        return response
+        return self.get_response(request)
 
 
 class PersistentApisixUserMiddleware(

--- a/src/apigateway/mitol/apigateway/views.py
+++ b/src/apigateway/mitol/apigateway/views.py
@@ -22,18 +22,9 @@ def get_redirect_url(request):
         str: Redirect URL
     """
     log.debug("views.get_redirect_url: Request GET is: %s", request.GET.get("next"))
-    log.debug(
-        "views.get_redirect_url: Request cookie is: %s", request.COOKIES.get("next")
-    )
 
-    next_url = request.GET.get("next") or request.COOKIES.get("next")
+    next_url = request.GET.get("next")
     log.debug("views.get_redirect_url: Redirect URL (before valid check): %s", next_url)
-
-    if request.COOKIES.get("next"):
-        # Clear the cookie after using it
-        log.debug("views.get_redirect_url: Popping the next cookie")
-
-        request.COOKIES.pop("next", None)
 
     return (
         next_url

--- a/tests/apigateway/test_views.py
+++ b/tests/apigateway/test_views.py
@@ -19,7 +19,7 @@ def user():
 
 
 @pytest.fixture(autouse=True)
-def _apigateway_reqs():
+def apigateway_reqs():
     """
     Make sure our backend and middleware are in place.
 
@@ -47,8 +47,7 @@ def _apigateway_reqs():
 
 
 @pytest.mark.parametrize("has_apisix_header", [True, False])
-@pytest.mark.parametrize("next_url", ["/search", None])
-def test_logout(next_url, client, user, has_apisix_header):
+def test_logout(client, user, has_apisix_header):
     """User should be properly redirected and logged out"""
     header_str = b64encode(
         json.dumps(
@@ -61,80 +60,11 @@ def test_logout(next_url, client, user, has_apisix_header):
     )
     client.force_login(user)
     response = client.get(
-        f"{INTERNAL_LOGOUT_URL_PATH}/?next={next_url or ''}",
+        INTERNAL_LOGOUT_URL_PATH,
         follow=False,
         HTTP_X_USERINFO=header_str if has_apisix_header else None,
     )
     if has_apisix_header:
         assert response.url == settings.MITOL_APIGATEWAY_LOGOUT_URL
-        if next_url:
-            assert response.cookies.get("next")
-            assert response.cookies["next"].value == (
-                next_url
-                if next_url
-                else settings.MITOL_APIGATEWAY_DEFAULT_POST_LOGOUT_DEST
-            )
     else:
-        assert response.url == (
-            next_url if next_url else settings.MITOL_APIGATEWAY_DEFAULT_POST_LOGOUT_DEST
-        )
-
-
-@pytest.mark.parametrize("is_authenticated", [True])
-@pytest.mark.parametrize("has_next", [False])
-@pytest.mark.parametrize("next_host_is_invalid", [True, False])
-def test_next_logout(  # noqa: PLR0913
-    mocker, client, user, is_authenticated, has_next, next_host_is_invalid
-):
-    """Test logout redirect cache assignment"""
-    next_url = "https://ocw.mit.edu"
-    mock_request = mocker.MagicMock(
-        GET={"next": next_url if has_next else None},
-    )
-    original_allowed_hosts = settings.MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS
-    settings.MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS = [
-        "testserver",
-        "invalid.com" if next_host_is_invalid else "ocw.mit.edu",
-    ]
-    if is_authenticated:
-        client.force_login(user)
-        mock_request.user = user
-        mock_request.META = {
-            "HTTP_X_USERINFO": b64encode(
-                json.dumps(
-                    {
-                        "username": user.username,
-                        "email": user.email,
-                        "global_id": user.global_id,
-                    }
-                ).encode()
-            ),
-        }
-    url_params = f"?next={next_url}" if has_next else ""
-    resp = client.get(
-        f"{INTERNAL_LOGOUT_URL_PATH}/{url_params}",
-        request=mock_request,
-        follow=False,
-        HTTP_X_USERINFO=b64encode(
-            json.dumps(
-                {
-                    "username": user.username,
-                    "email": user.email,
-                    "global_id": user.global_id,
-                }
-            ).encode()
-        ),
-    )
-    assert resp.status_code == 302  # noqa: PLR2004
-    if is_authenticated:
-        # APISIX header is present, so user should be logged out there
-        assert resp.url == settings.MITOL_APIGATEWAY_LOGOUT_URL
-    elif next_host_is_invalid:
-        # If host isn't in the allow list, this should always go to the default.
-        assert resp.url.endswith(settings.MITOL_APIGATEWAY_DEFAULT_POST_LOGOUT_DEST)
-    else:
-        assert resp.url.endswith(
-            next_url if has_next else settings.MITOL_APIGATEWAY_DEFAULT_POST_LOGOUT_DEST
-        )
-
-    settings.MITOL_APIGATEWAY_ALLOWED_REDIRECT_HOSTS = original_allowed_hosts
+        assert response.url == (settings.MITOL_APIGATEWAY_DEFAULT_POST_LOGOUT_DEST)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Related to https://github.com/mitodl/hq/issues/8977 and https://github.com/mitodl/hq/issues/8940

### Description (What does it do?)
<!--- Describe your changes in detail -->
Removes the usages of the `next` cookie. This was causing issues with either rogue or absent redirects in both mitxonline and learn. The next url works when routing is correctly configured so this isn't necessary anymore.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Apps that use this already are ignoring the cookie, so tests passing is good enough.
