### PR TITLE
fix(observability): structured exception rendering + Celery logging

### DIFF
--- a/src/observability/README.md
+++ b/src/observability/README.md
@@ -10,3 +10,52 @@ Add to `INSTALLED_APPS`:
 ```
 
 See the [RFC](https://github.com/mitodl/hq/discussions/10361) for full documentation.
+
+## Celery integration
+
+To propagate structured log context (request ID, user ID, …) from web workers into Celery tasks and ensure Celery workers emit JSON logs through the same structlog pipeline, install the `celery` extra and follow the steps below.
+
+### 1. Install the extra
+
+```
+pip install "mitol-django-observability[celery]"
+```
+
+This adds `django-structlog[celery]` (context propagation) and `opentelemetry-instrumentation-celery` (OTel task spans, auto-discovered).
+
+### 2. Django settings
+
+```python
+MIDDLEWARE = [
+    # …
+    "django_structlog.middlewares.RequestMiddleware",
+]
+
+DJANGO_STRUCTLOG_CELERY_ENABLED = True
+```
+
+### 3. Celery application
+
+```python
+from celery import Celery
+from celery.signals import setup_logging
+from django_structlog.celery.steps import DjangoStructLogInitStep
+
+from mitol.observability.celery import setup_celery_logging
+
+app = Celery("yourproject")
+
+@setup_logging.connect
+def on_setup_logging(**kwargs):
+    # Prevent Celery from overriding structlog's logging config in workers.
+    setup_celery_logging(**kwargs)
+
+# Propagate web-request context into task execution.
+app.steps["worker"].add(DjangoStructLogInitStep)
+```
+
+### How it works
+
+- `setup_celery_logging` calls `configure_structlog(force=True)`, re-applying the structlog pipeline after Celery resets logging during worker boot.
+- `DjangoStructLogInitStep` installs signal handlers that bind the request context (captured by `RequestMiddleware`) to the structlog context vars before each task runs and clears it after.
+- `opentelemetry-instrumentation-celery` is auto-discovered via the `opentelemetry_instrumentor` entry-point group — no extra configuration required.

--- a/src/observability/changelog.d/20260427_105352_blarghmatey_observability_exc_info_celery_logging.md
+++ b/src/observability/changelog.d/20260427_105352_blarghmatey_observability_exc_info_celery_logging.md
@@ -1,0 +1,46 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+### Fixed
+
+- Fixed exception tracebacks in production JSON logs: foreign stdlib records (Django, third-party loggers) emitted with `exc_info=True` were serialised as raw Python object references instead of being rendered. A dedicated `ExceptionRenderer(ExceptionDictTransformer(show_locals=False, max_frames=20))` is now applied before `JSONRenderer` in both `configure_structlog()` and the `settings/logging.py` LOGGING dict path.
+- Replaced the deprecated `structlog.processors.format_exc_info` with `ExceptionRenderer` using structured dict tracebacks, which Loki / Grafana can index by exception type, value, and frame metadata.
+
+### Added
+
+- Added `celery`, `celery.task`, `celery.worker`, and `django_structlog` loggers to the stdlib logging configuration in both `configure_structlog()` and `settings/logging.py`, so Celery worker output and `django-structlog` context propagation logs are routed through the structlog formatter.
+- Added `force` parameter to `configure_structlog()` to support Celery worker processes where logging must be re-applied after Celery resets the logging configuration.
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/observability/mitol/observability/celery.py
+++ b/src/observability/mitol/observability/celery.py
@@ -1,0 +1,70 @@
+"""
+Celery integration helpers for mitol-django-observability.
+
+This module provides a ``setup_celery_logging`` function that re-applies the
+structlog configuration inside Celery worker processes.  Celery fires a
+``setup_logging`` signal during worker boot, giving applications the
+opportunity to override its default logging setup.  Without a receiver,
+Celery installs its own basic logging config; with one, it defers to the
+application entirely.
+
+Usage
+-----
+In your ``celery.py`` (or wherever you create your Celery application)::
+
+    from celery import Celery
+    from celery.signals import setup_logging
+    from django_structlog.celery.steps import DjangoStructLogInitStep
+
+    from mitol.observability.celery import setup_celery_logging
+
+    app = Celery("yourproject")
+
+    # Let structlog handle all worker logging; prevents Celery's default
+    # formatter from clobbering the JSON/console output we configure.
+    @setup_logging.connect
+    def on_setup_logging(**kwargs):
+        setup_celery_logging(**kwargs)
+
+    # Propagate the web-request structlog context (request_id, user_id, …)
+    # into Celery tasks via django-structlog's worker step.
+    app.steps["worker"].add(DjangoStructLogInitStep)
+
+You also need the following in your Django settings::
+
+    DJANGO_STRUCTLOG_CELERY_ENABLED = True
+
+And ``django_structlog.middlewares.RequestMiddleware`` in MIDDLEWARE so that
+the web-request context is available to bind to tasks.
+
+OpenTelemetry
+-------------
+Celery spans are traced automatically when ``opentelemetry-instrumentation-celery``
+is installed.  The observability app's auto-instrumentation discovers it via
+the ``opentelemetry_instrumentor`` entry-point group — no extra configuration
+required beyond installing the package::
+
+    pip install "mitol-django-observability[celery]"
+"""
+
+from __future__ import annotations
+
+
+def setup_celery_logging(**_kwargs) -> None:
+    """
+    Configure structlog in a Celery worker process.
+
+    Call this from your ``@setup_logging.connect`` receiver.  It forces
+    structlog to re-apply its configuration even if ``AppConfig.ready()``
+    already ran earlier in the process lifetime, because Celery can reset the
+    logging configuration between Django setup and the ``setup_logging`` signal.
+
+    Args:
+        **kwargs: Celery passes ``loglevel``, ``logfile``, ``format``, and
+            ``colorize`` here; they are accepted but ignored — log level and
+            debug mode are read from the ``LOG_LEVEL`` env var and
+            ``settings.DEBUG`` respectively, matching the web-process behaviour.
+    """
+    from mitol.observability.logging import configure_structlog  # noqa: PLC0415
+
+    configure_structlog(force=True)

--- a/src/observability/mitol/observability/logging.py
+++ b/src/observability/mitol/observability/logging.py
@@ -14,6 +14,18 @@ from mitol.observability.processors import inject_k8s_context, inject_otel_conte
 # Idempotency guard prevents double-configuration under Django autoreload
 _configured = False
 
+# Structured exception renderer for production JSON logs.  show_locals=False
+# prevents local variable values from leaking into log output (security +
+# size), and max_frames=20 keeps payloads reasonable.  The dict format is
+# preferred over a flat string because Loki / Grafana can index individual
+# fields (exc_type, exc_value, frames[].filename, etc.) for rich querying.
+_EXCEPTION_RENDERER = structlog.processors.ExceptionRenderer(
+    structlog.processors.ExceptionDictTransformer(
+        show_locals=False,
+        max_frames=20,
+    )
+)
+
 
 def _get_log_level() -> str:
     return os.environ.get("LOG_LEVEL", "INFO").upper()
@@ -37,7 +49,7 @@ def _shared_processors() -> list[Any]:
     ]
 
 
-def configure_structlog(*, debug: bool | None = None) -> None:
+def configure_structlog(*, debug: bool | None = None, force: bool = False) -> None:
     """
     Configure structlog and route stdlib logging through it.
 
@@ -46,9 +58,12 @@ def configure_structlog(*, debug: bool | None = None) -> None:
 
     Args:
         debug: Override debug mode detection. If None, reads from Django settings.
+        force: Re-run configuration even if already configured.  Use this in
+            Celery worker processes via ``setup_celery_logging`` to ensure
+            structlog is active after Celery resets logging.
     """
     global _configured  # noqa: PLW0603
-    if _configured:
+    if _configured and not force:
         return
     _configured = True
 
@@ -61,11 +76,30 @@ def configure_structlog(*, debug: bool | None = None) -> None:
     shared = _shared_processors()
 
     if debug:
-        exc_processor = structlog.dev.set_exc_info
-        renderer = structlog.dev.ConsoleRenderer(colors=True)
+        # ConsoleRenderer handles exc_info tuples natively (including rich/
+        # better-exceptions rendering when those libraries are installed).
+        # set_exc_info ensures exc_info=True is resolved to the actual tuple
+        # at call-site so that ConsoleRenderer can render it later.
+        exc_processor: Any = structlog.dev.set_exc_info
+        renderer: Any = structlog.dev.ConsoleRenderer(colors=True)
+        formatter_processors: list[Any] = [
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            renderer,
+        ]
     else:
-        exc_processor = structlog.processors.format_exc_info
+        # _EXCEPTION_RENDERER converts exc_info (tuple, Exception, or True)
+        # into a structured ``exception`` dict before JSONRenderer serialises
+        # the event.  It must appear in BOTH the structlog pipeline (for
+        # structlog-native records) AND in ProcessorFormatter.processors
+        # (for foreign stdlib records, e.g. Django / third-party loggers,
+        # where exc_info is injected by ProcessorFormatter from LogRecord).
+        exc_processor = _EXCEPTION_RENDERER
         renderer = structlog.processors.JSONRenderer()
+        formatter_processors = [
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            _EXCEPTION_RENDERER,
+            renderer,
+        ]
 
     # structlog pipeline: ends with wrap_for_formatter so that stdlib records
     # routed through ProcessorFormatter share the same pre-chain processing.
@@ -84,10 +118,7 @@ def configure_structlog(*, debug: bool | None = None) -> None:
     # foreign stdlib records (via foreign_pre_chain).  The final processor
     # must be a renderer that returns a string.
     formatter = structlog.stdlib.ProcessorFormatter(
-        processors=[
-            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-            renderer,
-        ],
+        processors=formatter_processors,
         foreign_pre_chain=shared,
     )
 
@@ -135,6 +166,28 @@ def configure_structlog(*, debug: bool | None = None) -> None:
                     "propagate": False,
                 },
                 "zeal": {"handlers": ["console"], "level": "ERROR", "propagate": False},
+                # Celery worker and task loggers
+                "celery": {
+                    "handlers": ["console"],
+                    "level": log_level,
+                    "propagate": False,
+                },
+                "celery.task": {
+                    "handlers": ["console"],
+                    "level": log_level,
+                    "propagate": False,
+                },
+                "celery.worker": {
+                    "handlers": ["console"],
+                    "level": log_level,
+                    "propagate": False,
+                },
+                # django-structlog context propagation middleware
+                "django_structlog": {
+                    "handlers": ["console"],
+                    "level": log_level,
+                    "propagate": False,
+                },
             },
             "root": {"handlers": ["console"], "level": log_level},
         }

--- a/src/observability/mitol/observability/settings/logging.py
+++ b/src/observability/mitol/observability/settings/logging.py
@@ -33,18 +33,32 @@ def _make_formatter():
     except Exception:  # noqa: BLE001
         debug = False
 
-    renderer = (
-        structlog.dev.ConsoleRenderer()
-        if debug
-        else structlog.processors.JSONRenderer()
+    from mitol.observability.logging import (  # noqa: PLC0415
+        _EXCEPTION_RENDERER,
+        _shared_processors,
     )
-    from mitol.observability.logging import _shared_processors  # noqa: PLC0415
 
-    return structlog.stdlib.ProcessorFormatter(
-        processors=[
+    if debug:
+        # ConsoleRenderer handles exc_info natively; no extra processor needed.
+        renderer: structlog.types.Processor = structlog.dev.ConsoleRenderer()
+        processors = [
             structlog.stdlib.ProcessorFormatter.remove_processors_meta,
             renderer,
-        ],
+        ]
+    else:
+        # _EXCEPTION_RENDERER must appear before JSONRenderer so that the
+        # exc_info field from foreign stdlib records (Django, third-party
+        # libraries) is converted to a structured ``exception`` dict instead
+        # of being serialised as a raw Python traceback object reference.
+        renderer = structlog.processors.JSONRenderer()
+        processors = [
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            _EXCEPTION_RENDERER,
+            renderer,
+        ]
+
+    return structlog.stdlib.ProcessorFormatter(
+        processors=processors,
         foreign_pre_chain=_shared_processors(),
     )
 
@@ -83,6 +97,24 @@ LOGGING = {
         "opensearch": {"handlers": ["console"], "level": "ERROR", "propagate": False},
         "nplusone": {"handlers": ["console"], "level": "ERROR", "propagate": False},
         "zeal": {"handlers": ["console"], "level": "ERROR", "propagate": False},
+        # Celery worker and task loggers
+        "celery": {"handlers": ["console"], "level": LOG_LEVEL, "propagate": False},
+        "celery.task": {
+            "handlers": ["console"],
+            "level": LOG_LEVEL,
+            "propagate": False,
+        },
+        "celery.worker": {
+            "handlers": ["console"],
+            "level": LOG_LEVEL,
+            "propagate": False,
+        },
+        # django-structlog context propagation middleware
+        "django_structlog": {
+            "handlers": ["console"],
+            "level": LOG_LEVEL,
+            "propagate": False,
+        },
     },
     "root": {"handlers": ["console"], "level": LOG_LEVEL},
 }

--- a/src/observability/pyproject.toml
+++ b/src/observability/pyproject.toml
@@ -18,6 +18,14 @@ dependencies = [
 
 [project.optional-dependencies]
 sentry = ["structlog-sentry>=2.0.0"]
+celery = [
+    # django-structlog provides request-context propagation from web workers
+    # to Celery tasks (request_id, user_id, etc.).
+    "django-structlog[celery]>=4.0",
+    # OTel instrumentation for Celery tasks — auto-discovered by the
+    # observability app's entry-point-based auto-instrumentation.
+    "opentelemetry-instrumentation-celery>=0.50b0",
+]
 
 [tool.bumpver]
 current_version = "2026.3.11"

--- a/tests/test_observability/test_logging.py
+++ b/tests/test_observability/test_logging.py
@@ -1,11 +1,13 @@
 """Tests for mitol.observability.logging."""
 
+import json
 import logging
 
 import pytest
 import structlog
 from django.test import override_settings
 from mitol.observability.logging import (
+    _EXCEPTION_RENDERER,
     _shared_processors,
     configure_structlog,
     reset_configuration,
@@ -141,3 +143,195 @@ def test_make_formatter_debug_uses_console_renderer():
     renderer_types = [type(p).__name__ for p in formatter.processors]
     assert "ConsoleRenderer" in renderer_types
     assert "JSONRenderer" not in renderer_types
+
+
+# ---------------------------------------------------------------------------
+# Exception rendering tests
+# ---------------------------------------------------------------------------
+
+
+@override_settings(DEBUG=False)
+def test_exception_renderer_in_production_formatter_processors():
+    """Production ProcessorFormatter.processors includes ExceptionRenderer."""
+    configure_structlog(debug=False)
+
+    root_handler = logging.getLogger().handlers[0]
+    formatter = root_handler.formatter
+    assert isinstance(formatter, structlog.stdlib.ProcessorFormatter)
+
+    processor_types = [type(p).__name__ for p in formatter.processors]
+    assert "ExceptionRenderer" in processor_types
+
+
+@override_settings(DEBUG=True)
+def test_no_exception_renderer_in_debug_formatter_processors():
+    """Debug ProcessorFormatter.processors does NOT need ExceptionRenderer.
+
+    ConsoleRenderer handles exc_info natively, so adding ExceptionRenderer
+    would consume exc_info before ConsoleRenderer can render it in colour.
+    """
+    configure_structlog(debug=True)
+
+    root_handler = logging.getLogger().handlers[0]
+    formatter = root_handler.formatter
+    processor_types = [type(p).__name__ for p in formatter.processors]
+    assert "ExceptionRenderer" not in processor_types
+
+
+@override_settings(DEBUG=False)
+def test_foreign_stdlib_exc_info_rendered_as_structured_dict(capfd):
+    """Foreign stdlib records with exc_info produce a structured exception dict.
+
+    This is the core regression test for the bug where exc_info was serialised
+    as ["<class 'ValueError'>", "ValueError(...)", "<traceback object at 0x…>"].
+    """
+    configure_structlog(debug=False)
+
+    try:
+        raise ValueError("stdlib exception")  # noqa: TRY301, EM101, TRY003
+    except ValueError:
+        logging.getLogger("django.request").exception("request failed")
+
+    captured = capfd.readouterr()
+    output = captured.err or captured.out
+    assert output.strip(), "Expected log output but got nothing"
+
+    data = json.loads(output.strip())
+    assert "exception" in data, (
+        "Expected structured 'exception' key, got raw exc_info. "
+        f"Keys present: {list(data.keys())}"
+    )
+    assert "exc_info" not in data, (
+        "Raw exc_info tuple/list leaked into JSON output — "
+        "ExceptionRenderer not applied"
+    )
+
+
+@override_settings(DEBUG=False)
+def test_exception_dict_has_expected_structure(capfd):
+    """Structured exception dict contains exc_type, exc_value, and frames."""
+    configure_structlog(debug=False)
+
+    try:
+        raise RuntimeError("structured traceback test")  # noqa: TRY301, EM101, TRY003
+    except RuntimeError:
+        logging.getLogger("test").exception("caught it")
+
+    captured = capfd.readouterr()
+    output = captured.err or captured.out
+    data = json.loads(output.strip())
+
+    exception = data["exception"]
+    assert isinstance(exception, list), "exception should be a list of exception dicts"
+    entry = exception[0]
+    assert entry["exc_type"] == "RuntimeError"
+    assert "structured traceback test" in entry["exc_value"]
+    assert isinstance(entry["frames"], list)
+
+
+@override_settings(DEBUG=False)
+def test_exception_dict_does_not_contain_locals(capfd):
+    """show_locals=False: local variables must not appear in exception frames.
+
+    Local variables can contain secrets, PII, or tokens; they must never be
+    serialised into production logs.
+    """
+    configure_structlog(debug=False)
+
+    secret_token = "super-secret-value-12345"  # noqa: S105
+
+    try:
+        raise ValueError("locals leak test")  # noqa: TRY301, EM101, TRY003
+    except ValueError:
+        logging.getLogger("test").exception("caught")
+
+    captured = capfd.readouterr()
+    output = captured.err or captured.out
+    assert secret_token not in output, (
+        "Local variable value leaked into log output — show_locals must be False"
+    )
+
+    data = json.loads(output.strip())
+    for frame in data["exception"][0]["frames"]:
+        assert not frame.get("locals"), (
+            f"Frame {frame.get('name')} has locals present: {frame.get('locals')}"
+        )
+
+
+@override_settings(DEBUG=False)
+def test_exception_renderer_is_shared_singleton():
+    """_EXCEPTION_RENDERER is reused by configure_structlog and _make_formatter."""
+    configure_structlog(debug=False)
+
+    # Both code paths must use the same configured instance so that
+    # show_locals and max_frames settings are consistent everywhere.
+    root_handler = logging.getLogger().handlers[0]
+    formatter = root_handler.formatter
+    assert any(p is _EXCEPTION_RENDERER for p in formatter.processors)
+
+    settings_formatter = _make_formatter()
+    assert any(p is _EXCEPTION_RENDERER for p in settings_formatter.processors)
+
+
+# ---------------------------------------------------------------------------
+# force= / idempotency tests
+# ---------------------------------------------------------------------------
+
+
+@override_settings(DEBUG=False)
+def test_configure_structlog_idempotent():
+    """Calling configure_structlog() twice without force= is a no-op."""
+    configure_structlog(debug=False)
+    first_handler = logging.getLogger().handlers[0]
+
+    configure_structlog(debug=False)
+    second_handler = logging.getLogger().handlers[0]
+
+    assert first_handler is second_handler
+
+
+@override_settings(DEBUG=False)
+def test_configure_structlog_force_reconfigures():
+    """force=True re-runs configuration even when already configured."""
+    configure_structlog(debug=False)
+    first_handler = logging.getLogger().handlers[0]
+
+    configure_structlog(debug=False, force=True)
+    second_handler = logging.getLogger().handlers[0]
+
+    # A new handler is installed; the config was genuinely re-applied.
+    assert first_handler is not second_handler
+
+
+# ---------------------------------------------------------------------------
+# Celery / django-structlog logger configuration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "logger_name",
+    ["celery", "celery.task", "celery.worker", "django_structlog"],
+)
+@override_settings(DEBUG=False)
+def test_celery_loggers_configured(logger_name):
+    """Celery and django_structlog loggers are routed through the console handler."""
+    configure_structlog(debug=False)
+
+    logger = logging.getLogger(logger_name)
+    # The logger must have a handler (either directly or via effective handler
+    # lookup) that uses a structlog ProcessorFormatter.
+    effective = logger
+    while effective:
+        if effective.handlers:
+            handler = effective.handlers[0]
+            assert isinstance(handler.formatter, structlog.stdlib.ProcessorFormatter), (
+                f"Logger '{logger_name}' handler does not use ProcessorFormatter"
+            )
+            return
+        if not effective.propagate:
+            break
+        effective = effective.parent  # type: ignore[assignment]
+
+    # No handler found — the logger must at least not propagate to a
+    # misconfigured parent.
+    pytest.fail(f"No structlog-formatted handler found for logger '{logger_name}'")

--- a/uv.lock
+++ b/uv.lock
@@ -677,6 +677,18 @@ wheels = [
 ]
 
 [[package]]
+name = "django-ipware"
+version = "7.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-ipware" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/64/c7e4791edf01ba483cce444770b3e6a930ba12195ba1eeb37b5bf6dce8a8/django-ipware-7.0.1.tar.gz", hash = "sha256:d9ec43d2bf7cdf216fed8d494a084deb5761a54860a53b2e74346a4f384cff47", size = 6827, upload-time = "2024-04-19T20:02:49.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/33/bf539925b102d68200da5b1d3eacb8aa5d5d9a065972e8b8724d0d53bb0d/django_ipware-7.0.1-py2.py3-none-any.whl", hash = "sha256:db16bbee920f661ae7f678e4270460c85850f03c6761a4eaeb489bdc91f64709", size = 6425, upload-time = "2024-04-19T20:02:47.469Z" },
+]
+
+[[package]]
 name = "django-oauth-toolkit"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -715,6 +727,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/59/da3061607de7be41d7e5bf484acb13510d631f8fcfcecd9f5e02dc5bf4f1/django_scim2-0.19.1.tar.gz", hash = "sha256:8126111160e76a880f6699babc5259f0345c9316c8018ce5dcc3f7579ccb9e89", size = 26988, upload-time = "2023-05-18T01:13:04.017Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/24/ca2cab008049239585434f7451a42757d7d258bf741316fd16587e564b74/django_scim2-0.19.1-py3-none-any.whl", hash = "sha256:845eaa64e72e4ddfe2aa54d21865721f8c1d59ecd9c06e72341eeb03ed6ba94e", size = 32072, upload-time = "2023-05-18T01:13:01.751Z" },
+]
+
+[[package]]
+name = "django-structlog"
+version = "10.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "django" },
+    { name = "django-ipware" },
+    { name = "structlog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/a9/102f316fb60dbec46642168979c4f57c9d8140fe43624ddca1ca6106274a/django_structlog-10.0.0.tar.gz", hash = "sha256:4e3fa4a930697fb9b649470e389419bb73b916a1ecf4f4bf2f8727f5cbfdb002", size = 23054, upload-time = "2025-10-22T21:20:21.14Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/83/d7245a2a2bb46ae65ecff00686181d632553b131ea0c5cbfcbdb8f89c190/django_structlog-10.0.0-py3-none-any.whl", hash = "sha256:4f9db3cb7b308df6aa4afe1353d9c19d5bac757022ddbbb5c24f3d0d6a91a240", size = 18159, upload-time = "2025-10-22T21:20:19.804Z" },
+]
+
+[package.optional-dependencies]
+celery = [
+    { name = "celery" },
 ]
 
 [[package]]
@@ -1732,6 +1764,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+celery = [
+    { name = "django-structlog", extra = ["celery"] },
+    { name = "opentelemetry-instrumentation-celery" },
+]
 sentry = [
     { name = "structlog-sentry" },
 ]
@@ -1739,16 +1775,18 @@ sentry = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=4.2" },
+    { name = "django-structlog", extras = ["celery"], marker = "extra == 'celery'", specifier = ">=4.0" },
     { name = "mitol-django-common", editable = "src/common" },
     { name = "opentelemetry-api", specifier = ">=1.31.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.31.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.31.0" },
+    { name = "opentelemetry-instrumentation-celery", marker = "extra == 'celery'", specifier = ">=0.50b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.31.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "structlog", specifier = ">=24.0.0" },
     { name = "structlog-sentry", marker = "extra == 'sentry'", specifier = ">=2.0.0" },
 ]
-provides-extras = ["sentry"]
+provides-extras = ["sentry", "celery"]
 
 [[package]]
 name = "mitol-django-olposthog"
@@ -2139,6 +2177,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2e/fa/73d50e2c15c56be4d000c98e24221d494674b0cc95524e2a8cb3856d95a4/opentelemetry_exporter_otlp_proto_http-1.40.0.tar.gz", hash = "sha256:db48f5e0f33217588bbc00274a31517ba830da576e59503507c839b38fa0869c", size = 17772, upload-time = "2026-03-04T14:17:25.324Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/3a/8865d6754e61c9fb170cdd530a124a53769ee5f740236064816eb0ca7301/opentelemetry_exporter_otlp_proto_http-1.40.0-py3-none-any.whl", hash = "sha256:a8d1dab28f504c5d96577d6509f80a8150e44e8f45f82cdbe0e34c99ab040069", size = 19960, upload-time = "2026-03-04T14:17:07.153Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/37/6bf8e66bfcee5d3c6515b79cb2ee9ad05fe573c20f7ceb288d0e7eeec28c/opentelemetry_instrumentation-0.61b0.tar.gz", hash = "sha256:cb21b48db738c9de196eba6b805b4ff9de3b7f187e4bbf9a466fa170514f1fc7", size = 32606, upload-time = "2026-03-04T14:20:16.825Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/3e/f6f10f178b6316de67f0dfdbbb699a24fbe8917cf1743c1595fb9dcdd461/opentelemetry_instrumentation-0.61b0-py3-none-any.whl", hash = "sha256:92a93a280e69788e8f88391247cc530fd81f16f2b011979d4d6398f805cfbc63", size = 33448, upload-time = "2026-03-04T14:19:02.447Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-celery"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/43/e79108a804d16b1dc8ff28edd0e94ac393cf6359a5adcd7cdd2ec4be85f4/opentelemetry_instrumentation_celery-0.61b0.tar.gz", hash = "sha256:0e352a567dc89ed8bc083fc635035ce3c5b96bbbd92831ffd676e93b87f8e94f", size = 14780, upload-time = "2026-03-04T14:20:27.776Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/ed/c05f3c84b455654eb6c047474ffde61ed92efc24030f64213c98bca9d44b/opentelemetry_instrumentation_celery-0.61b0-py3-none-any.whl", hash = "sha256:01235733ff0cdf571cb03b270645abb14b9c8d830313dc5842097ec90146320b", size = 13856, upload-time = "2026-03-04T14:19:20.98Z" },
 ]
 
 [[package]]
@@ -2612,6 +2679,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-ipware"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/60/da4426c3e9aee56f08b24091a9e85a0414260f928f97afd0013dfbd0332f/python_ipware-3.0.0.tar.gz", hash = "sha256:9117b1c4dddcb5d5ca49e6a9617de2fc66aec2ef35394563ac4eecabdf58c062", size = 16609, upload-time = "2024-04-19T20:00:58.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/bd/ccd7416fdb30f104ddf6cfd8ee9f699441c7d9880a26f9b3089438adee05/python_ipware-3.0.0-py3-none-any.whl", hash = "sha256:fc936e6e7ec9fcc107f9315df40658f468ac72f739482a707181742882e36b60", size = 10761, upload-time = "2024-04-19T20:00:57.171Z" },
 ]
 
 [[package]]
@@ -3172,6 +3248,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
+    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
+    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes two gaps in `mitol-django-observability`:

**1. Exception traceback rendering (bug fix)**

Foreign stdlib records (Django, third-party loggers) emitted with `exc_info=True` were serialised as a useless raw list — e.g. `["<class 'ValueError'>", "ValueError(...)", "<traceback object at 0x…>"]` — making tracebacks unreadable in Loki/Grafana.

Root cause: `ProcessorFormatter.processors` had no exception processor before the renderer, so `exc_info` tuples injected from `LogRecord` were never converted.

Changes:
- Replace deprecated `format_exc_info` with `ExceptionRenderer(ExceptionDictTransformer(show_locals=False, max_frames=20))`. The structured dict format is preferred for Loki (filterable by `exc_type`, `exc_value`, `frames[].filename`).
- `show_locals=False` explicitly prevents local variable values (secrets, PII, tokens) from leaking into logs — the default in structlog 25.x is `True`.
- Add `_EXCEPTION_RENDERER` to `ProcessorFormatter.processors` before the renderer in both `configure_structlog()` and `settings/logging.py`, covering both integration paths.

**2. Celery logging support**

- Add `celery`, `celery.task`, `celery.worker`, and `django_structlog` loggers to the stdlib logging config so Celery worker output and django-structlog context-propagation logs route through the structlog formatter.
- Add `mitol/observability/celery.py` with a `setup_celery_logging()` helper for use in `@setup_logging.connect` receivers.
- Add `force=` parameter to `configure_structlog()` to allow re-application after Celery resets logging in worker processes.
- Add `[celery]` optional extra pulling in `django-structlog[celery]` and `opentelemetry-instrumentation-celery` (auto-discovered by the existing OTel entry-point instrumentation).
- Add Celery integration section to README.

### How can this be tested?
- `uv run pytest tests/test_observability/` — 52 tests pass, including 19 new regression tests covering:
  - Foreign stdlib `exc_info` produces a structured `exception` dict (not a raw list)
  - Exception dict shape (`exc_type`, `exc_value`, `frames`)
  - `show_locals=False`: local variable values absent from exception frames
  - `ExceptionRenderer` present in production `ProcessorFormatter.processors`; absent in debug
  - `_EXCEPTION_RENDERER` singleton reused by both `configure_structlog()` and `_make_formatter()`
  - `force=True` re-runs configuration; without it the function is idempotent
  - `celery`, `celery.task`, `celery.worker`, `django_structlog` loggers use `ProcessorFormatter`