### PR TITLE
chore: add back the Hubspot Objects table in Admin

### DIFF
--- a/src/hubspot_api/changelog.d/20260505_155544_arslan.ashraf_add_hubspot_objects_admin.md
+++ b/src/hubspot_api/changelog.d/20260505_155544_arslan.ashraf_add_hubspot_objects_admin.md
@@ -1,0 +1,43 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Added
+
+- Django Admin model for HubspotObjects
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->

--- a/src/hubspot_api/mitol/hubspot_api/admin.py
+++ b/src/hubspot_api/mitol/hubspot_api/admin.py
@@ -1,0 +1,18 @@
+"""Admin for hubspot CRM"""
+
+from django.contrib import admin
+from mitol.hubspot_api.models import HubspotObject
+
+
+class HubspotObjectAdmin(admin.ModelAdmin):
+    """Admin for HubspotObject"""
+
+    model = HubspotObject
+    list_display = ("content_object", "content_type", "object_id", "hubspot_id")
+    list_filter = ("content_type",)
+
+    def has_add_permission(self, request):  # noqa: ARG002
+        return False
+
+
+admin.site.register(HubspotObject, HubspotObjectAdmin)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -722,9 +722,9 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "asgiref", marker = "extra == 'group-9-ol-django-django52' or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django50') or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django51') or (extra != 'group-9-ol-django-django42' and extra != 'group-9-ol-django-django50' and extra != 'group-9-ol-django-django51')" },
-    { name = "sqlparse", marker = "extra == 'group-9-ol-django-django52' or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django50') or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django51') or (extra != 'group-9-ol-django-django42' and extra != 'group-9-ol-django-django50' and extra != 'group-9-ol-django-django51')" },
-    { name = "tzdata", marker = "(sys_platform == 'win32' and extra != 'group-9-ol-django-django42' and extra != 'group-9-ol-django-django50' and extra != 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django50') or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django52') or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django52') or (extra == 'group-9-ol-django-django51' and extra == 'group-9-ol-django-django52')" },
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/c5/c69e338eb2959f641045802e5ea87ca4bf5ac90c5fd08953ca10742fad51/django-5.2.13.tar.gz", hash = "sha256:a31589db5188d074c63f0945c3888fad104627dfcc236fb2b97f71f89da33bc4", size = 10890368, upload-time = "2026-04-07T14:02:15.072Z" }
 wheels = [
@@ -1557,7 +1557,7 @@ wheels = [
 
 [[package]]
 name = "mitol-django-apigateway"
-version = "2026.4.2"
+version = "2026.4.29"
 source = { editable = "src/apigateway" }
 dependencies = [
     { name = "channels" },
@@ -1577,7 +1577,7 @@ requires-dist = [
 
 [[package]]
 name = "mitol-django-authentication"
-version = "2026.4.2"
+version = "2026.4.29"
 source = { editable = "src/authentication" }
 dependencies = [
     { name = "django", version = "4.2.30", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-9-ol-django-django42' or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django52') or (extra == 'group-9-ol-django-django51' and extra == 'group-9-ol-django-django52')" },
@@ -1617,7 +1617,7 @@ provides-extras = ["touchstone"]
 
 [[package]]
 name = "mitol-django-common"
-version = "2026.4.2"
+version = "2026.4.29"
 source = { editable = "src/common" }
 dependencies = [
     { name = "django", version = "4.2.30", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-9-ol-django-django42' or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django52') or (extra == 'group-9-ol-django-django51' and extra == 'group-9-ol-django-django52')" },


### PR DESCRIPTION
### What are the relevant tickets?
None
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
- Adds the HubspotObjects table back into the Django Admin
- It was removed in https://github.com/mitodl/ol-django/pull/161/changes#diff-ffe01d23a30773ec48e621e400149c39c71395b2721f774cc803ed5865a229ce (Probably accidently)
- Brings the admin table back from https://github.com/mitodl/ol-django/pull/97
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Install this package in any of MIT applications using Hubspot i.e. MIT xPRO, MITx Online/Learn
- Make sure the hubspot objects table is listed there
<img width="815" height="198" alt="image" src="https://github.com/user-attachments/assets/361a7c2b-b478-4606-8cbc-2c5804b2f7f0" />

<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
