### PR TITLE
Optional template_path argument to media_convert_job

### DIFF
--- a/src/transcoding/changelog.d/20260520_142637_mattbert_transcoding_template_path.md
+++ b/src/transcoding/changelog.d/20260520_142637_mattbert_transcoding_template_path.md
@@ -1,0 +1,3 @@
+### Added
+
+- `media_convert_job()` and `make_media_convert_job()` now accept an optional `template_path` argument that overrides `settings.TRANSCODE_JOB_TEMPLATE` for a single call. This lets a project dispatch jobs through multiple templates (e.g. landscape vs. portrait pipelines) without mutating settings.

--- a/src/transcoding/mitol/transcoding/api.py
+++ b/src/transcoding/mitol/transcoding/api.py
@@ -25,6 +25,7 @@ def media_convert_job(  # noqa: PLR0913
         settings.VIDEO_S3_TRANSCODE_BUCKET or settings.AWS_STORAGE_BUCKET_NAME
     ),
     group_settings: dict | None = None,
+    template_path: str | None = None,
 ) -> dict:
     """
     Create a MediaConvert job for a Video
@@ -36,6 +37,8 @@ def media_convert_job(  # noqa: PLR0913
         destination_prefix (str): Prefix for the destination video.
         destination_bucket (str): S3 bucket for the transcoded output
         group_settings (dict, optional): Settings for output groups.
+        template_path (str, optional): Path to a MediaConvert job template to
+            use instead of ``settings.TRANSCODE_JOB_TEMPLATE``.
 
     Returns:
         dict: MediaConvert job details.
@@ -51,7 +54,7 @@ def media_convert_job(  # noqa: PLR0913
     )
 
     # Make MediaConvert job
-    job_dict = make_media_convert_job(file_config)
+    job_dict = make_media_convert_job(file_config, template_path=template_path)
 
     client = boto3.client(
         "mediaconvert",
@@ -61,18 +64,23 @@ def media_convert_job(  # noqa: PLR0913
     return client.create_job(**job_dict)
 
 
-def make_media_convert_job(file_config: FileConfig) -> dict:
+def make_media_convert_job(
+    file_config: FileConfig, template_path: str | None = None
+) -> dict:
     """
     Create a MediaConvert job config.
 
     Args:
         file_config (FileConfig): Configuration for file paths and settings.
+        template_path (str, optional): Path to a MediaConvert job template to
+            use instead of ``settings.TRANSCODE_JOB_TEMPLATE``.
 
     Returns:
         dict: MediaConvert job details.
     """
 
-    with Path(Path.cwd() / settings.TRANSCODE_JOB_TEMPLATE).open(
+    job_template_path = template_path or settings.TRANSCODE_JOB_TEMPLATE
+    with Path(Path.cwd() / job_template_path).open(
         encoding="utf-8",
     ) as job_template:
         job_dict = json.loads(job_template.read())

--- a/tests/transcoding/test_api.py
+++ b/tests/transcoding/test_api.py
@@ -257,3 +257,102 @@ def test_media_convert_job(mocker, exclude_mp4, exclude_thumbnail):
     )
 
     mock_client.create_job.assert_called_once_with(**mock_job_dict)
+
+
+def test_media_convert_job_forwards_template_path(mocker):
+    """media_convert_job should pass template_path through to make_media_convert_job."""
+    mocker.patch("boto3.client", return_value=mocker.MagicMock())
+    mock_make = mocker.patch(
+        "mitol.transcoding.api.make_media_convert_job", return_value={"job": "config"}
+    )
+    mocker.patch(
+        "django.conf.settings.VIDEO_S3_TRANSCODE_ENDPOINT",
+        "https://mediaconvert.us-east-1.amazonaws.com",
+    )
+    mocker.patch("django.conf.settings.AWS_REGION", "us-east-1")
+
+    media_convert_job(
+        "uploads/test-video.mp4",
+        template_path="config/portrait.json",
+    )
+
+    assert mock_make.call_args.kwargs["template_path"] == "config/portrait.json"
+
+
+def _write_template(path, marker):
+    """Write a minimal MediaConvert template and tag UserMetadata to identify it."""
+    path.write_text(
+        json.dumps(
+            {
+                "UserMetadata": {"filter": "", "template_marker": marker},
+                "Queue": "",
+                "Role": "",
+                "Settings": {
+                    "Inputs": [{"FileInput": ""}],
+                    "OutputGroups": [
+                        {
+                            "OutputGroupSettings": {
+                                "Type": GroupSettings.HLS_GROUP_SETTINGS,
+                                GroupSettings.HLS_GROUP_SETTINGS_KEY: {
+                                    "SegmentLength": 6,
+                                    "AdditionalManifests": [
+                                        {"ManifestNameModifier": ""}
+                                    ],
+                                },
+                                "Destination": "",
+                            },
+                            "Outputs": [
+                                {
+                                    "VideoDescription": {
+                                        "CodecSettings": {"Codec": "H_264"}
+                                    }
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+        )
+    )
+
+
+def test_make_media_convert_job_uses_template_path_override(
+    mock_file_config, tmp_path, mocker
+):
+    """make_media_convert_job reads template_path when provided, ignoring settings."""
+    default_template = tmp_path / "default.json"
+    override_template = tmp_path / "portrait.json"
+    _write_template(default_template, "default")
+    _write_template(override_template, "portrait")
+
+    mocker.patch("django.conf.settings.TRANSCODE_JOB_TEMPLATE", str(default_template))
+    mocker.patch("django.conf.settings.VIDEO_TRANSCODE_QUEUE", "default")
+    mocker.patch("django.conf.settings.AWS_REGION", "us-east-1")
+    mocker.patch("django.conf.settings.AWS_ACCOUNT_ID", "123456789012")
+    mocker.patch("django.conf.settings.AWS_ROLE_NAME", "MediaConvertRole")
+    mocker.patch("pathlib.Path.cwd", return_value=Path("/"))
+
+    job_dict = make_media_convert_job(
+        mock_file_config, template_path=str(override_template)
+    )
+
+    assert job_dict["UserMetadata"]["template_marker"] == "portrait"
+
+
+def test_make_media_convert_job_falls_back_to_settings_template(
+    mock_file_config, tmp_path, mocker
+):
+    """make_media_convert_job falls back to settings.TRANSCODE_JOB_TEMPLATE."""
+    default_template = tmp_path / "default.json"
+    _write_template(default_template, "default")
+
+    mocker.patch("django.conf.settings.TRANSCODE_JOB_TEMPLATE", str(default_template))
+    mocker.patch("django.conf.settings.VIDEO_TRANSCODE_QUEUE", "default")
+    mocker.patch("django.conf.settings.AWS_REGION", "us-east-1")
+    mocker.patch("django.conf.settings.AWS_ACCOUNT_ID", "123456789012")
+    mocker.patch("django.conf.settings.AWS_ROLE_NAME", "MediaConvertRole")
+    mocker.patch("pathlib.Path.cwd", return_value=Path("/"))
+
+    job_dict = make_media_convert_job(mock_file_config)
+
+    assert job_dict["UserMetadata"]["template_marker"] == "default"


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/11396

### Description (What does it do?)
 Adds an optional template_path argument to media_convert_job() and make_media_convert_job() so a project can dispatch jobs through more than one MediaConvert job template without modifying settings.TRANSCODE_JOB_TEMPLATE. When omitted, behavior is unchanged (settings.TRANSCODE_JOB_TEMPLATE value is used).


### How can this be tested?
See https://github.com/mitodl/odl-video-service/pull/1476
