### PR TITLE
Force pytest to render color output in GH actions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ include = ["CHANGELOG.md", "README.md", "py.typed", "**/*.py"]
 exclude = ["BUILD", "pyproject.toml"]
 
 [tool.pytest.ini_options]
-addopts = "--cov . --cov-report term --cov-report html --cov-report xml --reuse-db"
+addopts = "--cov . --cov-report term --cov-report html --cov-report xml --reuse-db --color=yes"
 norecursedirs = ".git .tox .* CVS _darcs {arch} *.egg dist"
 DJANGO_SETTINGS_MODULE = "main.settings.test"
 # -- recommended but optional:


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This forces pytest to render color output so that we can see failures in diffs easier.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
See the github action test output, the pytest run should include color text now.