### PR TITLE
only log prefetch errors in dev and during tests

### DIFF
--- a/src/common/mitol/common/serializers.py
+++ b/src/common/mitol/common/serializers.py
@@ -55,7 +55,7 @@ class BaseSerializer(serializers.ModelSerializer):
                     if settings.DEBUG or _running_under_pytest():
                         raise RequiredPrefetchMissingError(prefetch_name)
 
-                    log.warning(
+                    log.error(
                         "RequiredPrefetchMissing: serializer=%s prefetch=%s model=%s",
                         self.__class__.__name__,
                         prefetch_name,

--- a/src/common/mitol/common/serializers.py
+++ b/src/common/mitol/common/serializers.py
@@ -1,5 +1,9 @@
 """DRF serializers"""
 
+import logging
+import os
+
+from django.conf import settings
 from mitol.common.exceptions import (
     RequiredPrefetchesNotDefinedError,
     RequiredPrefetchMissingError,
@@ -7,8 +11,22 @@ from mitol.common.exceptions import (
 from mitol.common.utils.queryset import is_prefetched
 from rest_framework import serializers
 
+log = logging.getLogger(__name__)
+
 # sentinel object to indicate that you're disabling prefetch checks in non-API code
 THIS_IS_NOT_AN_API = object()
+
+
+def _running_under_pytest() -> bool:
+    """
+    Whether we appear to be running inside a pytest test run.
+
+    ol-django has no dedicated ``TESTING`` setting, and pytest-django forces
+    ``settings.DEBUG = False`` during tests, so ``DEBUG`` alone can't tell us
+    we're in a test. pytest exports ``PYTEST_CURRENT_TEST`` for the duration of
+    each test, which is the most reliable signal available here.
+    """
+    return "PYTEST_CURRENT_TEST" in os.environ
 
 
 class BaseSerializer(serializers.ModelSerializer):
@@ -28,6 +46,20 @@ class BaseSerializer(serializers.ModelSerializer):
         if self.context.get("skip_prefetch_checks", None) is not THIS_IS_NOT_AN_API:
             for prefetch_name in self.required_prefetches:
                 if not is_prefetched(instance, prefetch_name):
-                    raise RequiredPrefetchMissingError(prefetch_name)
+                    # In development, CI, and tests a missing required prefetch is a
+                    # programming error worth raising loudly so N+1 queries are caught
+                    # before they ship. In production we don't want a missing prefetch
+                    # to turn a slow-but-correct serialization into a hard 500, so we
+                    # log a structured, greppable warning and fall through to serialize
+                    # (lazily) instead.
+                    if settings.DEBUG or _running_under_pytest():
+                        raise RequiredPrefetchMissingError(prefetch_name)
+
+                    log.warning(
+                        "RequiredPrefetchMissing: serializer=%s prefetch=%s model=%s",
+                        self.__class__.__name__,
+                        prefetch_name,
+                        instance._meta.label,  # noqa: SLF001
+                    )
 
         return super().to_representation(instance)

--- a/tests/common/test_serializers.py
+++ b/tests/common/test_serializers.py
@@ -1,5 +1,8 @@
+import logging
+
 import pytest
 from main.models import FirstLevel1, FirstLevel2, SecondLevel1, SecondLevel2
+from mitol.common import serializers as serializers_module
 from mitol.common.exceptions import (
     RequiredPrefetchesNotDefinedError,
     RequiredPrefetchMissingError,
@@ -98,6 +101,61 @@ def test_serializer_asserts_missing_prefetch_related(django_assert_num_queries):
             }
             for first in qs
         ]
+
+
+@pytest.fixture
+def _simulate_production(settings, monkeypatch):
+    """
+    Make the serializer behave as it would in production: DEBUG off and not under
+    a (detected) pytest run, so the prefetch guardrail warns instead of raising.
+    """
+    settings.DEBUG = False
+    monkeypatch.setattr(serializers_module, "_running_under_pytest", lambda: False)
+
+
+@pytest.mark.usefixtures("_simulate_production")
+def test_serializer_warns_instead_of_raising_in_production(caplog):
+    """
+    Outside of development/CI/tests a missing required prefetch should not crash the
+    request. Instead it logs a structured warning and serializes lazily.
+    """
+    qs = FirstLevel1.objects.all()
+
+    with caplog.at_level(logging.WARNING):
+        data = _FirstLevel1Serializer(qs, many=True).data
+
+    assert data == [
+        {
+            "id": first.id,
+            "second_level": {"id": first.second_level.id},
+        }
+        for first in qs
+    ]
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == len(qs)
+    assert "RequiredPrefetchMissing" in caplog.text
+    assert "serializer=_FirstLevel1Serializer" in caplog.text
+    assert "prefetch=second_level" in caplog.text
+    assert f"model={FirstLevel1._meta.label}" in caplog.text  # noqa: SLF001
+
+
+@pytest.mark.usefixtures("_simulate_production")
+def test_serializer_prefetched_field_does_not_warn(caplog):
+    """A properly prefetched field serializes without warning or raising in prod"""
+    qs = FirstLevel1.objects.select_related("second_level")
+
+    with caplog.at_level(logging.WARNING):
+        data = _FirstLevel1Serializer(qs, many=True).data
+
+    assert data == [
+        {
+            "id": first.id,
+            "second_level": {"id": first.second_level.id},
+        }
+        for first in qs
+    ]
+    assert "RequiredPrefetchMissing" not in caplog.text
 
 
 def test_serializer_asserts_escape_hatch(django_assert_num_queries):

--- a/tests/common/test_serializers.py
+++ b/tests/common/test_serializers.py
@@ -107,21 +107,21 @@ def test_serializer_asserts_missing_prefetch_related(django_assert_num_queries):
 def _simulate_production(settings, monkeypatch):
     """
     Make the serializer behave as it would in production: DEBUG off and not under
-    a (detected) pytest run, so the prefetch guardrail warns instead of raising.
+    a (detected) pytest run, so the prefetch guardrail logs instead of raising.
     """
     settings.DEBUG = False
     monkeypatch.setattr(serializers_module, "_running_under_pytest", lambda: False)
 
 
 @pytest.mark.usefixtures("_simulate_production")
-def test_serializer_warns_instead_of_raising_in_production(caplog):
+def test_serializer_logs_error_instead_of_raising_in_production(caplog):
     """
     Outside of development/CI/tests a missing required prefetch should not crash the
-    request. Instead it logs a structured warning and serializes lazily.
+    request. Instead it logs a structured error and serializes lazily.
     """
     qs = FirstLevel1.objects.all()
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.ERROR):
         data = _FirstLevel1Serializer(qs, many=True).data
 
     assert data == [
@@ -132,20 +132,21 @@ def test_serializer_warns_instead_of_raising_in_production(caplog):
         for first in qs
     ]
 
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    assert len(warnings) == len(qs)
-    assert "RequiredPrefetchMissing" in caplog.text
-    assert "serializer=_FirstLevel1Serializer" in caplog.text
-    assert "prefetch=second_level" in caplog.text
-    assert f"model={FirstLevel1._meta.label}" in caplog.text  # noqa: SLF001
+    expected_message = (
+        "RequiredPrefetchMissing: serializer=_FirstLevel1Serializer "
+        f"prefetch=second_level model={FirstLevel1._meta.label}"  # noqa: SLF001
+    )
+    assert [r.getMessage() for r in caplog.records if r.levelno == logging.ERROR] == [
+        expected_message
+    ] * len(qs)
 
 
 @pytest.mark.usefixtures("_simulate_production")
-def test_serializer_prefetched_field_does_not_warn(caplog):
-    """A properly prefetched field serializes without warning or raising in prod"""
+def test_serializer_prefetched_field_does_not_log_error(caplog):
+    """A properly prefetched field serializes without logging or raising in prod"""
     qs = FirstLevel1.objects.select_related("second_level")
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.ERROR):
         data = _FirstLevel1Serializer(qs, many=True).data
 
     assert data == [


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11811

### Description (What does it do?)
This PR sets up the common serializer's prefetch rule to only throw during tests and when running local dev. The point is to fix those problems before they get to production, but if they do actually get there we shouldn't break the whole page and rather fetch the data lazily still.

### How can this be tested?
This needs to be tested in production, but you could potentially build and install the library here in a downstream dependency like MITx Online and manually trigger fetching of a resource without prefetch where required, or otherwise intentionally break prefetching.