### PR TITLE
fix: change drf-lint pragma to 'drf-lint' instead of noqa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      with:
+        version: "0.11.26"
 
     - name: Install dependencies
       run: uv sync
@@ -72,6 +74,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      with:
+        version: "0.11.26"
 
     - name: Pin python-version ${{ matrix.python-version }}
       run: uv python pin ${{ matrix.python-version }}
@@ -107,6 +111,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      with:
+        version: "0.11.26"
 
     # extract the app name out of the tag's ref value
     - id: get-app-name

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,6 +19,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      with:
+        version: "0.11.26"
 
     - name: Self-hosted Renovate
       uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd # v46.1.15

--- a/src/drf_lint/README.md
+++ b/src/drf_lint/README.md
@@ -58,13 +58,17 @@ Exit code is `0` when no new violations are found, `1` when violations are detec
 
 ## Suppressing individual violations
 
-Add `# noqa: ORM001` or `# noqa: ORM002` at the end of the offending line, or
-`# noqa` to suppress all rules on that line:
+Add `# drf-lint: ORM001` or `# drf-lint: ORM002` at the end of the offending
+line, or `# drf-lint` to suppress all rules on that line:
 
 ```python
 def get_image(self, instance):
-    item = instance.children.order_by("position").first()  # noqa: ORM002
+    item = instance.children.order_by("position").first()  # drf-lint: ORM002
 ```
+
+A dedicated pragma is used instead of `# noqa` because ruff (run separately in
+this repo) strips `# noqa` codes it doesn't recognize, which would silently
+remove the suppression.
 
 ## How it works
 

--- a/src/drf_lint/changelog.d/20260706_171231_asad.ali_change_drf_lint_pragme.rst
+++ b/src/drf_lint/changelog.d/20260706_171231_asad.ali_change_drf_lint_pragme.rst
@@ -1,0 +1,35 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the section that is right (remove the leading dots).
+.. For top level release notes, leave all the headers commented out.
+..
+.. Removed
+.. -------
+..
+.. - A bullet item for the Removed category.
+..
+.. Added
+.. -----
+..
+.. - A bullet item for the Added category.
+..
+.. Changed
+.. -------
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ----------
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. -----
+..
+.. - A bullet item for the Fixed category.
+..
+.. Security
+.. --------
+..
+.. - A bullet item for the Security category.
+..

--- a/src/drf_lint/mitol/drf_lint/checker.py
+++ b/src/drf_lint/mitol/drf_lint/checker.py
@@ -146,7 +146,10 @@ def _expr_contains_serializer(expr: cst.BaseExpression) -> bool:
 def check_source(
     source_code: str,
 ) -> list[Violation]:
-    """Parse *source_code* and return ORM violations, respecting ``# noqa`` comments."""
+    """Parse *source_code* and return ORM violations, respecting ``# drf-lint`` pragmas.
+
+    See :func:`_is_suppressed` for the pragma syntax.
+    """
     try:
         module = cst.parse_module(source_code)
     except cst.ParserSyntaxError:
@@ -157,7 +160,7 @@ def check_source(
     wrapper.visit(visitor)
 
     source_lines = source_code.splitlines()
-    return [v for v in visitor.violations if not _is_noqa(source_lines, v)]
+    return [v for v in visitor.violations if not _is_suppressed(source_lines, v)]
 
 
 def check_file(path: Path) -> list[Violation]:
@@ -165,18 +168,24 @@ def check_file(path: Path) -> list[Violation]:
     return check_source(path.read_text(encoding="utf-8"))
 
 
-def _is_noqa(source_lines: list[str], violation: Violation) -> bool:
-    """Return True if the violation's source line carries a ``# noqa`` suppression."""
+def _is_suppressed(source_lines: list[str], violation: Violation) -> bool:
+    """Return True if the violation's source line carries a ``# drf-lint`` suppression.
+
+    We use a dedicated ``# drf-lint`` pragma rather than ``# noqa`` because ruff
+    (run separately in this repo) treats unrecognized ``# noqa`` codes as unused
+    and strips them, which would silently remove these suppressions.
+    """
     if violation.line < 1 or violation.line > len(source_lines):
         return False
     line = source_lines[violation.line - 1]
-    if "# noqa" not in line:
+    if "# drf-lint" not in line:
         return False
-    # Bare noqa (no codes) suppresses everything on this line.
-    if "# noqa:" not in line:
+    # Bare pragma (no codes) suppresses everything on this line.
+    if "# drf-lint:" not in line:
         return True
-    # Specific rule codes, e.g. ``ORM001`` or ``ORM001,ORM002`` after "# noqa:"
+    # Specific rule codes, e.g. ``ORM001`` or ``ORM001,ORM002`` after "# drf-lint:"
     # Strip any trailing inline comment like ``# explanation``
-    noqa_part = line[line.index("# noqa:") + 7 :].split("#")[0].strip()
-    codes = {c.strip() for c in noqa_part.split(",")}
+    pragma_part = line[line.index("# drf-lint:") + len("# drf-lint:") :]
+    pragma_part = pragma_part.split("#")[0].strip()
+    codes = {c.strip() for c in pragma_part.split(",")}
     return violation.rule in codes

--- a/tests/drf_lint/test_orm001.py
+++ b/tests/drf_lint/test_orm001.py
@@ -122,50 +122,50 @@ class MySerializer(serializers.ModelSerializer):
 # ------------------------------------------------------------------ #
 
 
-def test_orm001_noqa_specific_code():
-    """A line with '# noqa: ORM001' suppresses the ORM001 violation on that line."""
+def test_orm001_drf_lint_pragma_specific_code():
+    """A line with '# drf-lint: ORM001' suppresses the ORM001 violation on that line."""
     source = """
 from rest_framework import serializers
 
 class MySerializer(serializers.Serializer):
     def get_obj(self, instance):
-        return MyModel.objects.get(pk=instance.pk)  # noqa: ORM001
+        return MyModel.objects.get(pk=instance.pk)  # drf-lint: ORM001
 """
     assert not _violations(source)
 
 
-def test_orm001_noqa_with_trailing_explanation():
-    """'# noqa: ORM001 # some explanation' suppresses the violation."""
+def test_orm001_drf_lint_pragma_with_trailing_explanation():
+    """'# drf-lint: ORM001 # some explanation' suppresses the violation."""
     source = """
 from rest_framework import serializers
 
 class MySerializer(serializers.Serializer):
     def get_obj(self, instance):
-        return MyModel.objects.get(pk=instance.pk)  # noqa: ORM001 # intentional
+        return MyModel.objects.get(pk=instance.pk)  # drf-lint: ORM001 # intentional
 """
     assert not _violations(source)
 
 
-def test_orm001_noqa_bare():
-    """A bare '# noqa' suppresses all violations on that line."""
+def test_orm001_drf_lint_pragma_bare():
+    """A bare '# drf-lint' suppresses all violations on that line."""
     source = """
 from rest_framework import serializers
 
 class MySerializer(serializers.Serializer):
     def get_obj(self, instance):
-        return MyModel.objects.get(pk=instance.pk)  # noqa
+        return MyModel.objects.get(pk=instance.pk)  # drf-lint
 """
     assert not _violations(source)
 
 
-def test_orm001_noqa_different_code_does_not_suppress():
-    """A '# noqa: ORM002' does NOT suppress an ORM001 violation on the same line."""
+def test_orm001_drf_lint_pragma_different_code_does_not_suppress():
+    """A '# drf-lint: ORM002' does NOT suppress an ORM001 violation on the same line."""
     source = """
 from rest_framework import serializers
 
 class MySerializer(serializers.Serializer):
     def get_obj(self, instance):
-        return MyModel.objects.get(pk=instance.pk)  # noqa: ORM002
+        return MyModel.objects.get(pk=instance.pk)  # drf-lint: ORM002
 """
     violations = _violations(source)
     assert any(v.rule == "ORM001" for v in violations)

--- a/tests/drf_lint/test_orm002.py
+++ b/tests/drf_lint/test_orm002.py
@@ -124,26 +124,26 @@ class MySerializer(serializers.Serializer):
     assert not _violations(source)
 
 
-def test_orm002_noqa_specific_code():
-    """A line with '# noqa: ORM002' suppresses the ORM002 violation on that line."""
+def test_orm002_drf_lint_pragma_specific_code():
+    """A line with '# drf-lint: ORM002' suppresses the ORM002 violation on that line."""
     source = """
 from rest_framework import serializers
 
 class MySerializer(serializers.Serializer):
     def get_prices(self, instance):
-        return list(instance.resource_prices.all())  # noqa: ORM002
+        return list(instance.resource_prices.all())  # drf-lint: ORM002
 """
     assert not _violations(source)
 
 
-def test_orm002_noqa_bare():
-    """A bare '# noqa' suppresses all violations on that line."""
+def test_orm002_drf_lint_pragma_bare():
+    """A bare '# drf-lint' suppresses all violations on that line."""
     source = """
 from rest_framework import serializers
 
 class MySerializer(serializers.Serializer):
     def get_prices(self, instance):
-        return list(instance.resource_prices.all())  # noqa
+        return list(instance.resource_prices.all())  # drf-lint
 """
     assert not _violations(source)
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
This PR replaces the `# noqa` pragma to `# drf-lint` as `# noqa` is used by Ruff and it can silently remove ORM001 and ORM001 as it does not recognize these rules.

While working on https://github.com/mitodl/mitxonline/pull/3731, I tried to add `# noqa: ORM001` but ruff removed it as part of pre-commit checks as it does not recongnize ORM001 and ORM002 rules.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- `# drf-lint` should ignore lines, and the plugin should flag ORM001 and ORM002 violations.