### PR TITLE
fix(apigateway): fix ApisixRemoteUserBackend.aauthenticate always returning None

### DIFF
--- a/src/apigateway/changelog.d/20260706_140955_blarghmatey.md
+++ b/src/apigateway/changelog.d/20260706_140955_blarghmatey.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed `ApisixRemoteUserBackend.aauthenticate` always returning `None`: it awaited nothing (missing `await`) and wrapped async ORM calls in a sync `transaction.atomic()`, which raises `SynchronousOnlyOperation` under a real event loop. Now delegates to the tested sync `authenticate()` via `sync_to_async`.

--- a/src/apigateway/mitol/apigateway/backends.py
+++ b/src/apigateway/mitol/apigateway/backends.py
@@ -106,7 +106,11 @@ class ApisixRemoteUserBackend(RemoteUserCustomFieldBackend):
         ``SynchronousOnlyOperation``), and the sync path is the one covered
         by tests.
         """
-        return await sync_to_async(self.authenticate)(request, remote_user)
+        if not remote_user:
+            return None
+        return await sync_to_async(self.authenticate, thread_sensitive=True)(
+            request, remote_user
+        )
 
     def configure_user(self, request, user, *, created=True):
         """

--- a/src/apigateway/mitol/apigateway/backends.py
+++ b/src/apigateway/mitol/apigateway/backends.py
@@ -3,6 +3,7 @@
 import contextlib
 import logging
 
+from asgiref.sync import sync_to_async
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -96,13 +97,16 @@ class ApisixRemoteUserBackend(RemoteUserCustomFieldBackend):
             return None
 
     async def aauthenticate(self, request, remote_user):
-        """See authenticate()."""
-        try:
-            with transaction.atomic():
-                return super().aauthenticate(request, remote_user)
-        except Exception:
-            log.exception("Unable to authenticate api gateway user")
-            return None
+        """See authenticate().
+
+        Delegates to the sync ``authenticate()`` (via ``sync_to_async``)
+        rather than awaiting ``super().aauthenticate()`` directly: the
+        latter's async ORM calls can't be wrapped in a plain
+        ``transaction.atomic()`` block from an async context (Django raises
+        ``SynchronousOnlyOperation``), and the sync path is the one covered
+        by tests.
+        """
+        return await sync_to_async(self.authenticate)(request, remote_user)
 
     def configure_user(self, request, user, *, created=True):
         """

--- a/tests/apigateway/test_backends.py
+++ b/tests/apigateway/test_backends.py
@@ -1,4 +1,5 @@
 import pytest
+from asgiref.sync import sync_to_async
 from django.contrib.auth import get_user_model
 from main.utils import generate_apisix_request, generate_fake_apisix_payload
 from mitol.apigateway.backends import ApisixRemoteUserBackend
@@ -44,3 +45,28 @@ def test_configure_user_updates_fields(settings, override, has_value):
     else:
         # If not overriding, the email should remain unchanged
         assert test_user.email == "updated@email.com"
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_aauthenticate_existing_user():
+    """Async authenticate should resolve an existing user, matching authenticate()."""
+    test_user = await sync_to_async(SsoUserFactory.create)()
+    payload, _ = generate_fake_apisix_payload(user=test_user)
+    request = await sync_to_async(generate_apisix_request)("request", payload)
+
+    backend = ApisixRemoteUserBackend()
+    result = await backend.aauthenticate(request, remote_user=test_user.global_id)
+
+    assert result is not None
+    assert result.global_id == test_user.global_id
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_aauthenticate_unknown_remote_user():
+    """Async authenticate should return None when there's no remote_user."""
+    backend = ApisixRemoteUserBackend()
+    result = await backend.aauthenticate(None, remote_user=None)
+
+    assert result is None

--- a/tests/apigateway/test_backends.py
+++ b/tests/apigateway/test_backends.py
@@ -47,7 +47,7 @@ def test_configure_user_updates_fields(settings, override, has_value):
         assert test_user.email == "updated@email.com"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_aauthenticate_existing_user():
     """Async authenticate should resolve an existing user, matching authenticate()."""
@@ -62,7 +62,7 @@ async def test_aauthenticate_existing_user():
     assert result.global_id == test_user.global_id
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_aauthenticate_unknown_remote_user():
     """Async authenticate should return None when there's no remote_user."""


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found during investigation for https://github.com/mitodl/hq/issues/12174 (learn-ai auth split-brain remediation, part of the SOA simplification & boundary-hardening backlog)

### Description (What does it do?)
`ApisixRemoteUserBackend.aauthenticate` had two independent bugs that made it silently non-functional under a real ASGI event loop:

- It called `super().aauthenticate(...)` without `await`ing it.
- It wrapped the call in a sync `transaction.atomic()` context manager, which raises `django.core.exceptions.SynchronousOnlyOperation` when entered from a running event loop.

Both failures were swallowed by the surrounding `except Exception: return None`, so `aauthenticate` always returned `None` — silent auth failure for any async caller, with no visible error.

No caller in ol-django or mitxonline currently invokes `aauthenticate` (grepped both), so this hasn't caused a production incident yet, but it's part of the documented async auth-backend interface Django's own auth machinery (`auser()`, `auth.aauthenticate()`) can invoke, and a downstream consumer (learn-ai) is fully async/ASGI and may want to rely on it going forward.

Fixed by delegating to the already-tested sync `authenticate()` via `sync_to_async`, matching the pattern `middleware_channels.py` already uses in this same package for the same reason (its `get_apisix_user` wraps the sync `backend.authenticate(...)` in `@database_sync_to_async` rather than calling `aauthenticate` at all).

### How can this be tested?
Added two regression tests in `tests/apigateway/test_backends.py`:
- `test_aauthenticate_existing_user` — confirms `aauthenticate` resolves an existing user by `global_id`, matching `authenticate()`'s behavior (previously returned `None` here due to the bugs above).
- `test_aauthenticate_unknown_remote_user` — confirms it returns `None` for a `None`/falsy `remote_user`.

All 30 tests in `tests/apigateway/` pass locally.

### Additional Context
No behavior change for any existing caller (nothing currently calls `aauthenticate`). Changelog fragment added under `src/apigateway/changelog.d/`.