### PR TITLE
fix: skip updating Hubspot properties with a read-only definition

### DIFF
--- a/src/hubspot_api/changelog.d/20260707_000000_fix_read_only_property_sync.rst
+++ b/src/hubspot_api/changelog.d/20260707_000000_fix_read_only_property_sync.rst
@@ -1,0 +1,9 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the section that is right (remove the leading dots).
+.. For top level release notes, leave all the headers commented out.
+..
+Fixed
+-----
+
+- ``sync_object_property`` no longer attempts to update properties with a read-only definition (e.g. properties created with ``hasUniqueValue=True``), which previously raised a 400 ``PROPERTY_INVALID`` error from Hubspot on re-runs.

--- a/src/hubspot_api/mitol/hubspot_api/api.py
+++ b/src/hubspot_api/mitol/hubspot_api/api.py
@@ -406,14 +406,26 @@ def sync_object_property(object_type: str, property_dict: str) -> SimplePublicOb
         if property_dict[key] is None:
             property_dict[key] = ""
 
-    exists = object_property_exists(object_type, property_dict["name"])
+    try:
+        existing_property = get_object_property(object_type, property_dict["name"])
+    except PropertiesApiException:
+        existing_property = None
 
-    if exists:
-        return HubspotApi().crm.properties.core_api.update(
-            object_type, property_dict["name"], property_dict
-        )
-    else:
+    if existing_property is None:
         return HubspotApi().crm.properties.core_api.create(object_type, property_dict)
+
+    # Properties with a read-only definition (e.g. those created with
+    # hasUniqueValue=True) can't be mutated in Hubspot. Attempting to update
+    # them raises a 400, so return the existing property unchanged instead.
+    modification_metadata = getattr(existing_property, "modification_metadata", None)
+    if modification_metadata is not None and getattr(
+        modification_metadata, "read_only_definition", False
+    ):
+        return existing_property
+
+    return HubspotApi().crm.properties.core_api.update(
+        object_type, property_dict["name"], property_dict
+    )
 
 
 def get_object_property(object_type: str, property_name: str) -> SimplePublicObject:

--- a/tests/hubspot_api/test_api.py
+++ b/tests/hubspot_api/test_api.py
@@ -134,9 +134,19 @@ def test_get_object_property(mock_hubspot_api):
 @pytest.mark.parametrize("object_exists", [True, False])
 def test_sync_object_property(mocker, mock_hubspot_api, object_exists, is_valid):
     """sync_object_property should call send_hubspot_request with the correct arguments"""  # noqa: E501
-    mocker.patch(
-        "mitol.hubspot_api.api.object_property_exists", return_value=object_exists
-    )
+    if object_exists:
+        existing_property = mocker.Mock(
+            modification_metadata=mocker.Mock(read_only_definition=False)
+        )
+        mocker.patch(
+            "mitol.hubspot_api.api.get_object_property",
+            return_value=existing_property,
+        )
+    else:
+        mocker.patch(
+            "mitol.hubspot_api.api.get_object_property",
+            side_effect=api.PropertiesApiException(),
+        )
     mock_properties = {
         "name": "property_name",
         "label": "Property Label",
@@ -160,6 +170,31 @@ def test_sync_object_property(mocker, mock_hubspot_api, object_exists, is_valid)
             mock_hubspot_api.return_value.crm.properties.core_api.create.assert_called_once_with(
                 test_object_type, mock_properties
             )
+
+
+def test_sync_object_property_skips_read_only_definition(mocker, mock_hubspot_api):
+    """sync_object_property should skip updating properties with a read-only definition"""  # noqa: E501
+    existing_property = mocker.Mock(
+        modification_metadata=mocker.Mock(read_only_definition=True)
+    )
+    mocker.patch(
+        "mitol.hubspot_api.api.get_object_property", return_value=existing_property
+    )
+    mock_properties = {
+        "name": "unique_app_id",
+        "label": "Unique App ID",
+        "groupName": "Property Group",
+        "description": "The unique app ID",
+        "field_type": "text",
+        "type": "string",
+        "hasUniqueValue": True,
+    }
+
+    result = api.sync_object_property(test_object_type, mock_properties)
+
+    assert result is existing_property
+    mock_hubspot_api.return_value.crm.properties.core_api.update.assert_not_called()
+    mock_hubspot_api.return_value.crm.properties.core_api.create.assert_not_called()
 
 
 @pytest.mark.parametrize("object_exists", [True, False])


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found while investigating a failing `configure_hubspot_properties` management command in mitxpro.

### Description (What does it do?)
`sync_object_property` performs an upsert: when a property already exists it PATCHes it with the full property dict (including `description`). Properties created with `hasUniqueValue=True` (e.g. the `unique_app_id` properties on deals, line items, and products) get a **read-only definition** in HubSpot once created, and HubSpot rejects any mutation of their definition.

As a result the first configuration of a HubSpot instance succeeds (every property is a `create`), but every subsequent run of `configure_hubspot_properties` fails with:

```
(400) ... The Property 'unique_app_id' has a read-only definition, and can't be mutated. The following fields were changed: [description]
```

Fixed by fetching the existing property once and skipping the `update()` call when its `modification_metadata.read_only_definition` is truthy — returning the existing property unchanged instead. `create` for missing properties and `update` for normal (mutable) existing properties are unchanged.

Adds a changelog fragment. The version bump is left for a separate release commit, per repo convention.

### How can this be tested?
- Updated `test_sync_object_property` in `tests/hubspot_api/test_api.py` (it now stubs `get_object_property` rather than the removed `object_property_exists` call).
- Added `test_sync_object_property_skips_read_only_definition`, which confirms a property whose `modification_metadata.read_only_definition` is `True` is returned unchanged and neither `create` nor `update` is invoked.

All `sync_object_property` tests in `tests/hubspot_api/test_api.py` pass locally.

Verified end-to-end by installing this branch editable into a mitxpro `web` container and running `./manage.py configure_hubspot_properties` against a real HubSpot instance — it now completes with exit code 0 and prints `Custom properties configured`, passing all three `unique_app_id` properties that previously raised the 400.

### Additional Context
No version bump in this PR — following the repo convention where releases are cut in separate "Release mitol-django-hubspot-api/vX" commits. The changelog fragment will be collected at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
