### PR TITLE
Fix the serialization of email_option to be 0 or 1

### DIFF
--- a/src/keycloak/changelog.d/20260713_152912_nlevesq_fix_keycloak_email_optin.md
+++ b/src/keycloak/changelog.d/20260713_152912_nlevesq_fix_keycloak_email_optin.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed `UserAttributes.email_optin` serializing to a raw boolean instead of the int (0/1) Keycloak expects.

--- a/src/keycloak/mitol/keycloak/data_models.py
+++ b/src/keycloak/mitol/keycloak/data_models.py
@@ -22,4 +22,8 @@ class UserAttributes(BaseModel):
     def as_array(self, value: Any) -> list[Any]:
         return [value]
 
+    @field_serializer("email_optin", mode="plain")
+    def serialize_email_optin(self, value: bool) -> list[int]:  # noqa: FBT001
+        return [int(value)]
+
     model_config = ConfigDict(serialize_by_alias=True, frozen=True)

--- a/tests/keycloak/test_api.py
+++ b/tests/keycloak/test_api.py
@@ -93,7 +93,7 @@ def test_update_user(responses: RequestsMock, settings):
         **initial,
         "attributes": {
             **initial["attributes"],
-            "emailOptIn": [True],
+            "emailOptIn": [1],
         },
     }
 
@@ -108,6 +108,6 @@ def test_update_user(responses: RequestsMock, settings):
         "attributes": {
             **initial["attributes"],
             "fullName": ["new_name"],
-            "emailOptIn": [False],
+            "emailOptIn": [0],
         },
     }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/8424

### Description (What does it do?)
<!--- Describe your changes in detail -->
We actually store this in keycloak as an integer of value 0 or 1 due to limitations with boolean fields in Keycloak. This fixes the serialization while still accepting a boolean.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass