### PR TITLE
Fix release script not adding uv.lock

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -63,6 +63,7 @@ def commit_and_tag(project: Project, app: App):
             app.absolute_path / "mitol" / app.module_name / "__init__.py",
             app.absolute_path / "pyproject.toml",
             app.absolute_path / "CHANGELOG.md",
+            app.absolute_path / "uv.lock",
         ]
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -1871,7 +1871,7 @@ requires-dist = [
 
 [[package]]
 name = "mitol-django-keycloak"
-version = "2026.4.29"
+version = "2026.7.13"
 source = { editable = "src/keycloak" }
 dependencies = [
     { name = "django", version = "4.2.30", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-9-ol-django-django42' or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django52') or (extra == 'group-9-ol-django-django51' and extra == 'group-9-ol-django-django52')" },


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This appear to have broken at some point, when releases are generated 'uv.lock' isn't committed. This also adds in the most recent `uv.lock` change that should've been committed.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass