### PR TITLE
Try again to disable renovate for test dep groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,11 +4,11 @@
     "local>mitodl/.github:renovate-config"
   ],
   "packageRules": [{
-    "matchDepName": "django",
-    "matchDepTypes": ["dependency-group"],
+    "matchDepNames": ["django"],
+    "matchDepTypes": ["dependency-groups"],
     "matchJsonata": [
-      "$match(managerData.depGroup, /django[0-9]+/)"
+      "$match(managerData.depGroup, /^django[0-9]+$/)"
     ],
-    "matchUpdateTypes": ["patch"]
+    "enabled": false
   }]
 }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Follow up to https://github.com/mitodl/ol-django/pull/452

### Description (What does it do?)
<!--- Describe your changes in detail -->
This will hopefully prevent PRs like https://github.com/mitodl/ol-django/pull/448 once and for all, I previously attempted this in https://github.com/mitodl/ol-django/pull/452, but it appears to not have worked. Claude suggested these changes.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass