### PR TITLE
observability: add postgres extra with the compiled psycopg binding

### DIFF
--- a/src/observability/README.md
+++ b/src/observability/README.md
@@ -59,3 +59,62 @@ app.steps["worker"].add(DjangoStructLogInitStep)
 - `setup_celery_logging` calls `configure_structlog(force=True)`, re-applying the structlog pipeline after Celery resets logging during worker boot.
 - `DjangoStructLogInitStep` installs signal handlers that bind the request context (captured by `RequestMiddleware`) to the structlog context vars before each task runs and clears it after.
 - `opentelemetry-instrumentation-celery` is auto-discovered via the `opentelemetry_instrumentor` entry-point group — no extra configuration required.
+
+## Postgres integration
+
+To emit OTel spans for database queries, install the `postgres` extra:
+
+```
+pip install "mitol-django-observability[postgres]"
+```
+
+This adds two things:
+
+- `opentelemetry-instrumentation-psycopg`, auto-discovered via the `opentelemetry_instrumentor` entry-point group — no extra configuration required.
+- `psycopg[c]`, the compiled binding, which is the implementation you want in production. The section below explains why the extra decides this on your behalf.
+
+### Build prerequisites
+
+`psycopg[c]` is compiled from source at install time, so the build environment needs a C compiler, Python development headers, `libpq-dev`, and `pg_config` on `PATH`. Images built on `mitodl/ol-python-base` already provide all four.
+
+CI runners generally do not. GitHub's `ubuntu-24.04` image, for instance, ships PostgreSQL but not `libpq-dev`, so add it to your `Aptfile` (or equivalent) alongside the other `-dev` packages:
+
+```
+libpq-dev
+```
+
+If you are in an environment that genuinely cannot compile, install `psycopg[binary]` explicitly in your application — a pre-compiled wheel that bundles its own `libpq` and `libssl`. Those bundled libraries do not receive OS security updates, which is why it is not the default here.
+
+### Why the extra decides the driver
+
+The psycopg instrumentation targets **psycopg 3**, so installing this extra puts psycopg 3 in your environment. That has a consequence which is easy to miss: it changes which driver Django uses. Django's Postgres backend prefers psycopg 3 over psycopg2 whenever psycopg 3 is importable ([`django/db/backends/postgresql/base.py`](https://github.com/django/django/blob/5.2.15/django/db/backends/postgresql/base.py#L24-L30)):
+
+```python
+try:
+    try:
+        import psycopg as Database
+    except ImportError:
+        import psycopg2 as Database
+```
+
+An application running on psycopg2 therefore switches to psycopg 3 the moment this instrumentation is installed, with no change to its own code and nothing in its dependency diff that names a driver.
+
+Since the extra is already making that decision, it specifies the implementation too. psycopg 3 ships three interchangeable bindings to libpq, and a bare `psycopg` dependency selects the slowest:
+
+| dependency | binding | notes |
+| --- | --- | --- |
+| `psycopg` | pure Python, via `ctypes` | upstream calls it "much slower"; intended for local development and small tasks |
+| `psycopg[c]` | compiled, linked against the system libpq | psycopg's recommendation for production — system `libpq`/`libssl` upgrades carry through |
+| `psycopg[binary]` | compiled, bundles its own libpq/libssl | no build tools needed, but the bundled libraries do not receive OS security updates |
+
+Extras union across dependency resolution, so requesting `psycopg[c]` here installs the compiled binding regardless of how the application declares psycopg itself.
+
+Check what a deployed process actually resolved to — psycopg selects the best available implementation at import, so this reflects what is installed rather than what was requested:
+
+```python
+>>> import psycopg
+>>> psycopg.pq.__impl__
+'c'
+```
+
+See psycopg's [installation guide](https://www.psycopg.org/psycopg3/docs/basic/install.html#install-grid) and [`pq` module implementations](https://www.psycopg.org/psycopg3/docs/api/pq.html#pq-impl) for the full comparison.

--- a/src/observability/changelog.d/20260729_152325_chudzick_postgres_extra_and_psycopg_guidance.md
+++ b/src/observability/changelog.d/20260729_152325_chudzick_postgres_extra_and_psycopg_guidance.md
@@ -1,0 +1,5 @@
+### Added
+
+- Added a `postgres` extra providing `opentelemetry-instrumentation-psycopg` and `psycopg[c]`, the instrumentation being auto-discovered via the `opentelemetry_instrumentor` entry-point group.
+- Documented in the README why the extra decides the database driver: the instrumentation targets psycopg 3, and Django's Postgres backend prefers psycopg 3 over psycopg2 whenever it is importable, so installing it switches an application's driver with nothing in the dependency diff naming one. Since the extra already makes that decision, it pins the compiled binding rather than leaving a bare `psycopg` to resolve to the pure-Python `ctypes` implementation that upstream documents as "much slower".
+- Documented the resulting build prerequisites (C compiler, Python headers, `libpq-dev`, `pg_config` — all present in `ol-python-base`, absent from GitHub's `ubuntu-24.04` runners) and `psycopg[binary]` as the escape hatch for environments that cannot compile.

--- a/src/observability/pyproject.toml
+++ b/src/observability/pyproject.toml
@@ -26,6 +26,20 @@ celery = [
     # observability app's entry-point-based auto-instrumentation.
     "opentelemetry-instrumentation-celery>=0.50b0",
 ]
+postgres = [
+    # OTel instrumentation for psycopg queries — auto-discovered by the
+    # observability app's entry-point-based auto-instrumentation.
+    "opentelemetry-instrumentation-psycopg>=0.50b0",
+    # The instrumentation targets psycopg 3, and Django's postgresql backend
+    # prefers psycopg 3 over psycopg2 whenever it is importable — so installing
+    # this extra decides the application's database driver. Pin the compiled
+    # binding rather than leaving that to a bare `psycopg`, which resolves to
+    # the pure-Python ctypes implementation upstream calls "much slower".
+    # Requires a C compiler, Python headers, libpq-dev, and pg_config at build
+    # time; ol-python-base provides all four. See README.md if you need
+    # psycopg[binary] instead.
+    "psycopg[c]>=3.2.4",
+]
 
 [tool.bumpver]
 current_version = "2026.3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1982,6 +1982,10 @@ celery = [
     { name = "django-structlog", extra = ["celery"] },
     { name = "opentelemetry-instrumentation-celery" },
 ]
+postgres = [
+    { name = "opentelemetry-instrumentation-psycopg" },
+    { name = "psycopg", extra = ["c"] },
+]
 sentry = [
     { name = "structlog-sentry" },
 ]
@@ -1995,12 +1999,14 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.31.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.31.0" },
     { name = "opentelemetry-instrumentation-celery", marker = "extra == 'celery'", specifier = ">=0.50b0" },
+    { name = "opentelemetry-instrumentation-psycopg", marker = "extra == 'postgres'", specifier = ">=0.50b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.31.0" },
+    { name = "psycopg", extras = ["c"], marker = "extra == 'postgres'", specifier = ">=3.2.4" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "structlog", specifier = ">=24.0.0" },
     { name = "structlog-sentry", marker = "extra == 'sentry'", specifier = ">=2.0.0" },
 ]
-provides-extras = ["sentry", "celery"]
+provides-extras = ["sentry", "celery", "postgres"]
 
 [[package]]
 name = "mitol-django-olposthog"
@@ -2046,7 +2052,7 @@ requires-dist = [
 
 [[package]]
 name = "mitol-django-payment-gateway"
-version = "2026.4.2"
+version = "2026.7.15"
 source = { editable = "src/payment_gateway" }
 dependencies = [
     { name = "cybersource-rest-client-python" },
@@ -2447,6 +2453,35 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-instrumentation-dbapi"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/ed/ba91c9e4a3ec65781e9c59982109f0a36de9fa574f622596b33d1985dab5/opentelemetry_instrumentation_dbapi-0.61b0.tar.gz", hash = "sha256:02fa800682c1de87dcad0e59f2092b3b6fb8b8ea0636518f989e1166b418dcb9", size = 16761, upload-time = "2026-03-04T14:20:29.782Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/a5/d26c68f3fd33eb7410985cef7700bb426e2c4a26de9207902cbbffb19a3f/opentelemetry_instrumentation_dbapi-0.61b0-py3-none-any.whl", hash = "sha256:8f762c39c8edd20c6aef3282550a2cfbfec76c3f431bf5c36327dcf9ece2e5a0", size = 14134, upload-time = "2026-03-04T14:19:24.718Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-psycopg"
+version = "0.61b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-dbapi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/00/b98148b3054eb8301a56d523de82ee2fd86a047dba38330c2404d85496e3/opentelemetry_instrumentation_psycopg-0.61b0.tar.gz", hash = "sha256:74e9fed3802945f7ae335cffc30fd18cf58c34a4d0619315f799fa21eb5c74ff", size = 11907, upload-time = "2026-03-04T14:20:39.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/2b/3c36bfc6dc82a7c50c769aff407eaf32e688d655bc61a774609d96b55603/opentelemetry_instrumentation_psycopg-0.61b0-py3-none-any.whl", hash = "sha256:a3e242cad56c0ad4f4f872017c73ce7e6c7012081dda6bd0d776c127fedc358a", size = 11662, upload-time = "2026-03-04T14:19:41.108Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2615,6 +2650,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/28/50/1925de813499546bc8ab3ae857e3ec84efe7d2f19b34529d0c7c3d02d11d/protobuf-6.30.2-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4f6c687ae8efae6cf6093389a596548214467778146b7245e886f35e1485315d", size = 316212, upload-time = "2025-03-26T19:12:48.458Z" },
     { url = "https://files.pythonhosted.org/packages/e5/a1/93c2acf4ade3c5b557d02d500b06798f4ed2c176fa03e3c34973ca92df7f/protobuf-6.30.2-py3-none-any.whl", hash = "sha256:ae86b030e69a98e08c77beab574cbcb9fff6d031d57209f574a5aea1445f4b51", size = 167062, upload-time = "2025-03-26T19:12:55.892Z" },
 ]
+
+[[package]]
+name = "psycopg"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django50') or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django52') or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django52') or (extra == 'group-9-ol-django-django51' and extra == 'group-9-ol-django-django52')" },
+    { name = "tzdata", marker = "sys_platform == 'win32' or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django50') or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django52') or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django52') or (extra == 'group-9-ol-django-django51' and extra == 'group-9-ol-django-django52')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e0/7b3dee031daae7743609ce3c746565d4a3ed7c2c186479eb48e34e838c64/psycopg-3.3.4-py3-none-any.whl", hash = "sha256:b6bbc25ccf05c8fad3b061d9db2ef0909a555171b84b07f29458a447253d679a", size = 213001, upload-time = "2026-05-01T23:20:50.816Z" },
+]
+
+[package.optional-dependencies]
+c = [
+    { name = "psycopg-c", marker = "implementation_name != 'pypy' or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django50') or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django42' and extra == 'group-9-ol-django-django52') or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django51') or (extra == 'group-9-ol-django-django50' and extra == 'group-9-ol-django-django52') or (extra == 'group-9-ol-django-django51' and extra == 'group-9-ol-django-django52')" },
+]
+
+[[package]]
+name = "psycopg-c"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/7c/c08364f2eab2913e4068b3b955d963e7a3491986a85429990969525def30/psycopg_c-3.3.4.tar.gz", hash = "sha256:ed8106128b2d04359c185fc9641b4409abfce4d0b6fb1d1ff6800646e27f1a22", size = 647111, upload-time = "2026-05-01T23:31:58.032Z" }
 
 [[package]]
 name = "psycopg2-binary"


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Adds a `postgres` extra to `mitol-django-observability` and documents the psycopg implementation choice that comes with it.

Three services — mit-learn, mitxonline, and learn-ai — each ended up running psycopg 3's pure-Python `ctypes` binding in production, and in two of them it happened by accident. The mechanism is worth writing down because nothing in a dependency diff reveals it:

1. `opentelemetry-instrumentation-psycopg` targets psycopg 3, so adding it puts psycopg 3 in the environment.
2. Django's Postgres backend prefers psycopg 3 over psycopg2 whenever psycopg 3 is importable ([`base.py`](https://github.com/django/django/blob/5.2.15/django/db/backends/postgresql/base.py#L24-L30)). An app running happily on psycopg2's compiled extension therefore switches drivers on the spot.
3. A bare `psycopg` dependency resolves to the `ctypes` binding, which upstream [rates "🐢 Slow"](https://www.psycopg.org/psycopg3/docs/basic/install.html#install-grid) and describes as "much slower … likely sufficient for local developments or small tasks but, for production loads, you might want to install one of the speed-up extensions too."

In mit-learn and mitxonline, steps 1–3 all landed inside a commit whose subject was about adding OpenTelemetry. Verified on a mit-learn production pod:

```
driver module : psycopg 3.3.3
pq impl       : python
```

This PR does two things:

- **Consolidates the instrumentation** into a `postgres` extra, mirroring the existing `celery` extra, so the next service gets it from here instead of hand-copying an OTel dependency block.
- **Specifies the implementation** in that extra — `psycopg[c]`, the binding built against the system libpq — with a README section explaining why the extra is the thing making that call.

The reasoning for pinning rather than documenting: the extra is *already* deciding which driver Django uses, per the mechanism above. Declining to specify the implementation isn't neutrality, it's shipping the pure-Python binding by default — which is exactly how all three services ended up where they are. And it works mechanically, because extras union across resolution: requesting `psycopg[c]` here installs the compiled binding regardless of how the consuming application declares psycopg itself.

Every consumer of this package builds on `ol-python-base`, which provides the C compiler, Python headers, `libpq-dev`, and `pg_config` the source build needs. The README covers the two cases that differ: CI runners (GitHub's `ubuntu-24.04` ships PostgreSQL but not `libpq-dev`, so it needs an `Aptfile` line) and environments that genuinely cannot compile (`psycopg[binary]`, with the caveat that its bundled `libpq`/`libssl` don't get OS security updates).

**ol-django's own CI is unaffected** — `ci.yml` runs a plain `uv sync` with no extras, so `psycopg-c` is never built in this repo.

Driver fixes for the three services are separate, one-line PRs: [mit-learn#3701](https://github.com/mitodl/mit-learn/pull/3701), [mitxonline#3801](https://github.com/mitodl/mitxonline/pull/3801), [learn-ai#4](https://github.com/mitodl/learn-ai/pull/4).

### How can this be tested?

```bash
uv sync --extra postgres   # from src/observability, or via the workspace
uv run python -c "
from importlib.metadata import entry_points
print([e.name for e in entry_points(group='opentelemetry_instrumentor')])
"
```

`psycopg` should appear in the list, which is what `mitol.observability.telemetry` iterates over when auto-instrumenting (`telemetry.py:73`). Docs-only otherwise — no runtime code changed.

### Additional Context

- **Heads-up on `uv.lock`:** the root lockfile also moves `mitol-django-payment-gateway` from 2026.4.2 to 2026.7.15. That entry was **already stale on `main`** — `uv lock --check` fails on a pristine checkout, because the package's own `pyproject.toml` says 2026.7.15. Re-locking for the new extra necessarily corrects it. I left the correction in rather than hand-reverting the lock into a state that still fails `--check`, but flagging it since it's unrelated to the extra.
- The changelog fragment was written by hand to scriv's naming convention rather than via `scripts/changelog.py create`. That script can't run on my machine: `uv run` tries to build `psycopg2-binary` from source and fails for want of libpq headers — a fittingly on-topic failure.
- **The per-app PRs are still worth merging.** All three services currently declare `opentelemetry-instrumentation-psycopg` directly rather than via this extra, so the pin here only takes effect once they adopt it. The one-line `psycopg[c]` changes fix them now; this makes the next service correct by default.
- **Lock noise:** the `group-9-ol-django-django42/50/51/52` conflict markers on the new psycopg entries are uv's standard encoding for this workspace's Django version matrix, not something specific to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
